### PR TITLE
fix/#2-1 MobileLayout min-h-screen 수정

### DIFF
--- a/src/components/layout/MobileLayout.tsx
+++ b/src/components/layout/MobileLayout.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 const MobileLayout: React.FC<Props> = ({ children }) => {
   return (
-    <div className="max-w-[375px] mx-auto bg-mainBlack min-h-screen">
+    <div className="max-w-[375px] mx-auto bg-mainBlack  h-[100px]">
       {children}
     </div>
   )


### PR DESCRIPTION
# fix/#2-1 MobileLayout min-h-screen 수정

## 목적
- MobileLayout 100vh 높이를 차지로 인한 수정

## 상세 내용
-  min-h-screen 제거
-  h-[100px] 추가 
