### PR TITLE
[fix] 코어멤버  페이지 css 수정

### DIFF
--- a/src/pages/CoreMembers.tsx
+++ b/src/pages/CoreMembers.tsx
@@ -65,7 +65,7 @@ const CoreMembers: React.FC = () => {
   return (
     <MobileLayout>
       <Header/>
-      <div className='relative top-[28px] ml-[12px] flex'>
+      <div className='mt-[28px] ml-[12px] flex'>
           <img
               className='w-[21px] h-[24px] cursor-pointer'
               alt='logo'
@@ -77,7 +77,7 @@ const CoreMembers: React.FC = () => {
       </div>
       
       {/* 멤버 프로필 리스트 */}
-      <div className='ml-[12px] mt-[48px] text-white'>
+      <div className='ml-[12px] mt-[20px] text-white'>
         {profiles.map((member) => (
           <div key={member.id} className='flex mb-[20px] items-center justify-between pr-[12px]'>
             <div className="flex items-center">


### PR DESCRIPTION
[fix] 코어멤버  페이지 css 수정

## Issue
- #15 

## 변경 내용
- 헤더 메뉴 팝업 시 생기는 css 문제를 해결

## 구현 사항
- 헤더 메뉴 팝업 시 다솜 운영진 텍스트 및 로고 이미지가 메뉴 팝업 뒤로 가지지 않는 문제를 해결했습니다.
- relative top을 margin-top으로 수정 
