### PR TITLE
[feat] Recruit 페이지 & UI 컴포넌트, Button 컴포넌트,  InputField 컴포넌트 추가

### DIFF
--- a/src/components/UI/RecruitUI.tsx
+++ b/src/components/UI/RecruitUI.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+
+
+interface RecruitHeaderProps {
+  title: string;
+}
+
+export const RecruitHeader: React.FC<RecruitHeaderProps> = ({ title }) => {
+  return (
+    <div className=" w-full max-w-[375px] bg-[#00B493] text-white font-bold text-[11px] p-1 pl-2 ml-2.5">
+      {title}
+    </div>
+  )
+}
+
+
+export const RecruitUI: React.FC = () => {
+    return (     
+       <div className="  text-gray-300 flex flex-col items-start max-w-[375px] h-[250px] shadow-[0px_2px_3px_rgba(255,255,255,0.2)] bg-#17171B] gap-2 ml-2.5">
+        <p className="  text-[10px] font-bold pl-2 pt-2">
+          다솜에서 개발자로서 성장해갈 <span className="text-yellow-400 font-bold">34기 멤버분들</span>을 찾습니다!
+        </p>
+        <div className="mt-2 text-[10px] pl-2">
+          <p className="text-green-400 font-semibold">📅 모집 일정 :</p>
+          <p>모집 폼 제출 : 2/25(화) ~ 3/14(금)</p>
+          <p>대면 면접 : 3/19(수) ~ 3/21(금)</p>
+          <p>최종 합격자 발표 : 3/24(월)</p>
+        </div>
+
+        <div className="mt-2 text-[10px] pl-2">
+          <p className="text-green-400 font-semibold">📝 모집 대상 :
+          <span className="text-gray-300 pl-1">25년도 1학기부터 다솜과 함께할 예비 다솜 멤버</span>
+          </p>
+        </div>
+
+        <div className="mt-2 text-[10px] pl-2 ">
+          <p className="text-green-400 font-semibold">🌿 신청 조건 :
+          <span className="text-gray-300 pl-1">컴퓨터소프트웨어공학과 학생</span>
+          </p>
+        </div>
+
+        <div className="mt-2 text-[10px] pl-2">
+          <p className="text-green-400 font-semibold">💰 회비 :
+          <span className="text-gray-300 pl-1">20,000원 </span>
+          </p>
+          <p> 회비는 동아리 운영자금 및 프로젝트 서버비용 지원 등에 사용됩니다. </p>
+        </div>
+
+        <p className="mt-2 text-[10px] pl-2">👀 의지가 있으며 교류를 중시하는 분을 기다립니다.</p>
+      </div>
+    )
+}

--- a/src/components/UI/Recruit_Button.tsx
+++ b/src/components/UI/Recruit_Button.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+interface ButtonProps {
+  text: string;
+  className?: string;  // 추가적인 Tailwind 스타일 적용 가능
+}
+
+// 📌 button 컴포넌트
+export const Button: React.FC<ButtonProps> = ({ text, className }) => {
+  return (
+    <div className='w-full max-w-[395px] h-[50px] flex justify-center'>
+      <button
+        className={`bg-[#00B493] max-w-[395px] h-[22px] text-white font-bold px-4 text-[10px] transition-all hover:bg-[#00937A] active:scale-95 ${className}`}
+      >
+        {text}
+      </button>
+    </div>
+  )
+}
+
+
+
+

--- a/src/components/UI/Recruit_InputField.tsx
+++ b/src/components/UI/Recruit_InputField.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+
+interface InputFieldProps {
+  label: string;
+  subLabel?: string;
+  type?: 'text' | 'email' | 'textarea' | 'select' | 'checkbox' | 'test';
+  placeholder?: string;
+  required?: boolean;
+  options?: { value: string; label: string }[];
+  checkboxLabel?: string;
+}
+
+export const InputField: React.FC<InputFieldProps> = ({
+  label,
+  subLabel,
+  type = 'text',
+  placeholder,
+  required = false,
+  options = [],
+  checkboxLabel = '확인했습니다.',
+}) => {
+  
+  // 📌 공통 스타일 변수
+  const containerStyles = 'mb-4 p-3 shadow-[0px_2px_3px_rgba(255,255,255,0.2)] text-white'
+  const baseInputStyles = 'w-full bg-mainBlack border-b border-white  p-2 focus:outline-none text-[10px]'
+  const inputStyles = 'w-4 h-4 bg-mainBlack border border-white focus:ring-white border-2 appearance-none checked:bg-white checked:border-white" '
+
+  return (
+    <div className={containerStyles}>
+      <label className="block text-white text-[10px] font-bold mb-1">
+        {label.split('대면으로').map((part, index) => (
+          <span key={index}>
+            {part}
+            {index !== label.split('대면으로').length - 1 && (
+              <span className="text-red-500">대면으로</span>
+            )}
+          </span>
+        ))}
+        {type !== 'checkbox' && type !== 'test' && required && <span className="text-red-500 pl-1">*</span>}
+      </label>
+
+      {subLabel && <p className=" font-bold text-[10px] mb-3">{subLabel}</p>}
+
+      {type === 'select' ? (
+        <select className={baseInputStyles}>
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      ) : type === 'textarea' ? (
+        <textarea placeholder={placeholder} className={baseInputStyles} required={required} />
+
+      ) : type === 'checkbox' ? (
+        <div className="flex items-center space-x-2">
+          <input type="checkbox" className={inputStyles} required={required} />
+         
+          <span className="text-white text-[10px]">{checkboxLabel}</span>
+        </div>
+
+      ) : (
+        <input type={type} placeholder={placeholder} className={baseInputStyles} required={required} />
+      )}
+    </div>
+  )
+}

--- a/src/pages/Recruit.tsx
+++ b/src/pages/Recruit.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import MobileLayout from '../components/layout/MobileLayout'
+import { Header } from '../components/UI/Header'
+import { RecruitUI, RecruitHeader } from '../components/UI/RecruitUI'
+import { InputField } from '../components/UI/Recruit_InputField'
+import { Button } from '../components/UI/Recruit_Button'
+
+const Recruit: React.FC = () => {
+  return (
+    <MobileLayout>
+      <Header />
+      <RecruitHeader title="컴퓨터 소프트웨어 공학과 전공 동아리 다솜 34기 모집 폼" />
+      <RecruitUI />
+      <div className=" flex flex-col items-center gap-6">
+        <form className="mt-3 bg-mainBlack w-full px-2">
+          <InputField label="이름" required />
+          <InputField label="학번" required />
+          <InputField label="연락처" placeholder="ex) 010-0000-0000" required />
+          <InputField label="이메일" type="email" required />
+          <InputField
+            label="학년"
+            type="select"
+            required
+            options={[
+              { value: '1', label: '1학년' },
+              { value: '2', label: '2학년' },
+              { value: '3', label: '3학년' },
+              { value: '4', label: '4학년' },
+            ]}
+          />
+          <InputField label="지원동기 (500자 이내)" type='textarea' required />
+          <InputField label="동아리 내에서 하고 싶은 활동이 있다면 적어주세요!" type='textarea' required />
+          <InputField
+            label="🫧 면접 일자는 3월 15일(토)에 개별 연락처로 안내 후,"
+            subLabel="3월 19일부터 3월 21일까지 대면으로 진행됩니다."
+            type='checkbox'
+            required
+          />
+          <InputField
+            label="⚠️ 수집된 개인정보는 동아리 활동에 이용되며, 추후 파기됩니다."
+            subLabel="또한 제공받은 정보는 공지사항 전달 및 비상 연락 용도로만 사용됩니다."
+            type='checkbox'
+            required
+          />
+        </form>
+
+
+
+      </div>
+      <Button text="폼 제출하기" />
+    </MobileLayout>
+  )
+}
+
+export default Recruit


### PR DESCRIPTION
# [feat] Recruit 페이지 & UI 컴포넌트, Button 컴포넌트 추가

## Issue
- #6 

## 변경 내용
- 기존 Figma에 있던 Recruit 모집일정 컴포넌트 아이콘 및 텍스트 색깔 수정

## 구현 사항
- Recruit 페이지 구현
- RecruitUI.tsx, Recruit_ InputField.tsx, Recruit_Button.tsx 컴포넌트 구현

## 참고 사항
- RecruitUI 컴포넌트에 두 개의 컴포넌트 존재 (RecruitHeader, RecruitUI)
- RecruitResult.tsx, RecruitCheck.tsx 페이지로 인해 추후 RecruitUI와 Recruit_InputField 컴포넌트에 수정
- RecruitUI :  RecruitCheck.tsx의 컴포넌트 추가 
- Recruit_InputField : RecruitResult.tsx의 조건부 렌더링 컴포넌트 