### PR TITLE
[feat] 페이지 route 추가, Header 페이지 이동 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import './assets/styles/index.css'
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom'
 import Main from './pages/Main'
 import Login from './pages/Login'
 import RecruitMeeting from './pages/RecruitMeeting'
@@ -9,23 +9,37 @@ import News from './pages/News'
 import NewsInfo from './pages/NewsInfo'
 import Recruit from './pages/Recruit'
 import CoreMembers from './pages/CoreMembers'
+import { Header } from './components/UI/Header'
 
 function App() {
 	return (
 		<div className='App'>
 			<Router>
-				<Routes>
-					<Route path='/' element={<Main />} />
-					<Route path='/login' element={<Login />} />
-					<Route path='/recruit' element={<Recruit />} />
-					<Route path='/coremember' element={<CoreMembers />} />
-					<Route path='/recruit-meeting' element={<RecruitMeeting />} />
-					<Route path='/recruit-meeting/submit' element={<RecruitSubmitMeeting />} />
-					<Route path='/news' element={<News />} />
-					<Route path='/news/:no' element={<NewsInfo />} />
-				</Routes>
+				<AppContent />
 			</Router>
 		</div>
+	)
+}
+
+function AppContent() {
+	const location = useLocation()
+	const hideHeader = ['/login'] // 헤더를 숨길 페이지
+
+	return (
+		<>
+			{/* 지정한 페이지 header 숨기기 */}
+			{!hideHeader.includes(location.pathname) && <Header />}
+			<Routes>
+				<Route path='/' element={<Main />} />
+				<Route path='/login' element={<Login />} />
+				<Route path='/recruit' element={<Recruit />} />
+				<Route path='/coremember' element={<CoreMembers />} />
+				<Route path='/recruit-meeting' element={<RecruitMeeting />} />
+				<Route path='/recruit-meeting/submit' element={<RecruitSubmitMeeting />} />
+				<Route path='/news' element={<News />} />
+				<Route path='/news/:no' element={<NewsInfo />} />
+			</Routes>
+		</>
 	)
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import RecruitMeeting from './pages/RecruitMeeting'
 import RecruitSubmitMeeting from './pages/RecruitSubmitMeeting'
 import News from './pages/News'
 import NewsInfo from './pages/NewsInfo'
+import Recruit from './pages/Recruit'
+import CoreMembers from './pages/CoreMembers'
 
 function App() {
 	return (
@@ -14,7 +16,9 @@ function App() {
 			<Router>
 				<Routes>
 					<Route path='/' element={<Main />} />
-          <Route path='/login' element={<Login />} />
+					<Route path='/login' element={<Login />} />
+					<Route path='/recruit' element={<Recruit />} />
+					<Route path='/coremember' element={<CoreMembers />} />
 					<Route path='/recruit-meeting' element={<RecruitMeeting />} />
 					<Route path='/recruit-meeting/submit' element={<RecruitSubmitMeeting />} />
 					<Route path='/news' element={<News />} />

--- a/src/components/UI/Header.tsx
+++ b/src/components/UI/Header.tsx
@@ -37,7 +37,10 @@ export const Header = (): JSX.Element => {
             margin: '0 auto',
           }}
         >
-          <div className='font-black text-mainColor text-2xl cursor-pointer' onClick={() => navigate('/')}>DASOM</div>
+          <div className='font-black text-mainColor text-2xl cursor-pointer' onClick={() => {
+            navigate('/')
+            isMenuOpen? toggleMenu() : null
+            }}>DASOM</div>
 
           {/* 메뉴 버튼 */}
           <img
@@ -65,6 +68,7 @@ export const Header = (): JSX.Element => {
               className='font-pretendardBlack text-mainColor text-[20px] cursor-pointer hover:text-white'
               onClick={() => {console.log('About 이동')
                 navigate('/')
+                toggleMenu()
               }}
             >
               About
@@ -73,6 +77,7 @@ export const Header = (): JSX.Element => {
               className='font-pretendardBlack text-mainColor text-[20px] cursor-pointer hover:text-white'
               onClick={() => {console.log('News 이동')
                 navigate('/news')
+                toggleMenu()
               }}
             >
               News
@@ -81,6 +86,7 @@ export const Header = (): JSX.Element => {
               className='font-pretendardBlack text-mainColor text-[20px] cursor-pointer hover:text-white'
               onClick={() =>{console.log('Members 이동')
                 navigate('/coremember')
+                toggleMenu()
               }}
             >
               Members
@@ -89,6 +95,7 @@ export const Header = (): JSX.Element => {
               className='font-pretendardBlack text-mainColor text-[20px] cursor-pointer hover:text-white'
               onClick={() => {console.log('FAQ 이동')
                 navigate('/faq')
+                toggleMenu()
               }}
             >
               FAQ
@@ -97,6 +104,7 @@ export const Header = (): JSX.Element => {
               className='font-pretendardBlack text-white text-[20px] cursor-pointer hover:scale-110'
               onClick={() => {console.log('form 이동')
                 navigate('/recruit')
+                toggleMenu()
               }}
             >
               34기 지원하기
@@ -105,6 +113,7 @@ export const Header = (): JSX.Element => {
               className='font-pretendardBlack text-white text-[20px] cursor-pointer hover:scale-110'
               onClick={() => {console.log('합격여부 이동')
                 navigate('/')
+                toggleMenu()
               }}
             >
               합격여부 확인하기

--- a/src/components/UI/Header.tsx
+++ b/src/components/UI/Header.tsx
@@ -1,11 +1,13 @@
-import React, { JSX, useState, useEffect } from 'react'
+import React, { JSX, useState, useEffect, use } from 'react'
 import MobileLayout from '../layout/MobileLayout'
 import headerMenu from '../../assets/images/headerMenu.svg'
 import headerMenuUndo from '../../assets/images/headerMenuUndo.svg'
+import { useNavigate } from 'react-router-dom'
 
 export const Header = (): JSX.Element => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+  const navigate = useNavigate()
 
   const toggleMenu = () => {
     setIsMenuOpen((prev) => !prev)
@@ -35,7 +37,7 @@ export const Header = (): JSX.Element => {
             margin: '0 auto',
           }}
         >
-          <div className='font-black text-mainColor text-2xl'>DASOM</div>
+          <div className='font-black text-mainColor text-2xl cursor-pointer' onClick={() => navigate('/')}>DASOM</div>
 
           {/* 메뉴 버튼 */}
           <img
@@ -61,37 +63,49 @@ export const Header = (): JSX.Element => {
           <ul className='flex flex-col items-center space-y-6 text-center'>
             <li
               className='font-pretendardBlack text-mainColor text-[20px] cursor-pointer hover:text-white'
-              onClick={() => console.log('About 이동')}
+              onClick={() => {console.log('About 이동')
+                navigate('/')
+              }}
             >
               About
             </li>
             <li
               className='font-pretendardBlack text-mainColor text-[20px] cursor-pointer hover:text-white'
-              onClick={() => console.log('News 이동')}
+              onClick={() => {console.log('News 이동')
+                navigate('/news')
+              }}
             >
               News
             </li>
             <li
               className='font-pretendardBlack text-mainColor text-[20px] cursor-pointer hover:text-white'
-              onClick={() => console.log('Members 이동')}
+              onClick={() =>{console.log('Members 이동')
+                navigate('/coremember')
+              }}
             >
               Members
             </li>
             <li
               className='font-pretendardBlack text-mainColor text-[20px] cursor-pointer hover:text-white'
-              onClick={() => console.log('FAQ 이동')}
+              onClick={() => {console.log('FAQ 이동')
+                navigate('/faq')
+              }}
             >
               FAQ
             </li>
             <li
               className='font-pretendardBlack text-white text-[20px] cursor-pointer hover:scale-110'
-              onClick={() => console.log('form 이동')}
+              onClick={() => {console.log('form 이동')
+                navigate('/recruit')
+              }}
             >
               34기 지원하기
             </li>
             <li
               className='font-pretendardBlack text-white text-[20px] cursor-pointer hover:scale-110'
-              onClick={() => console.log('합격여부 이동')}
+              onClick={() => {console.log('합격여부 이동')
+                navigate('/')
+              }}
             >
               합격여부 확인하기
             </li>

--- a/src/pages/CoreMembers.tsx
+++ b/src/pages/CoreMembers.tsx
@@ -64,7 +64,6 @@ const GitHubLinkUrl = ({ username }: { username: string }) => {
 const CoreMembers: React.FC = () => {
   return (
     <MobileLayout>
-      <Header/>
       <div className='mt-[28px] ml-[12px] flex'>
           <img
               className='w-[21px] h-[24px] cursor-pointer'

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -62,7 +62,6 @@ const Main: React.FC = () => {
 
   return (
     <MobileLayout>
-      <Header />
       <div className='top-44 text-4xl md:text-[24px] lg:text-[36px] font-semibold max-w-7xl mx-auto text-center mt-6 relative z-20 py-6 bg-clip-text text-transparent bg-gradient-to-b from-neutral-100 via-neutral-400 to-neutral-300 dark:from-neutral-800 dark:via-white dark:to-white'>
         Code Beyond Limits, <br /> Discover <Cover>New Spaces</Cover> with <div className='text-mainColor'>DASOM</div>
       </div>

--- a/src/pages/News.tsx
+++ b/src/pages/News.tsx
@@ -31,7 +31,6 @@ const News: React.FC = () => {
 
 	return (
 		<MobileLayout>
-			<Header />
 			<div className='mt-[65px] mb-2 ml-[12px] flex'>
 				<img className='w-[21px] h-[24px] cursor-pointer' alt='logo' src={dasomLogo} />
 				<div className='font-pretendardSemiBold text-white text-[16px] ml-[9px]'>다솜 소식</div>

--- a/src/pages/NewsInfo.tsx
+++ b/src/pages/NewsInfo.tsx
@@ -15,7 +15,6 @@ interface notice {
 const NewsInfo: React.FC = () => {
 	return (
 		<MobileLayout>
-			<Header />
 			<div className='mt-[65px] mb-2 ml-[12px] flex'>
 				<img className='w-[21px] h-[24px] cursor-pointer' alt='logo' src={dasomLogo} />
 				<div className='font-pretendardSemiBold text-white text-[16px] ml-[9px]'>다솜 소식</div>

--- a/src/pages/Recruit.tsx
+++ b/src/pages/Recruit.tsx
@@ -8,7 +8,6 @@ import { Button } from '../components/UI/Recruit_Button'
 const Recruit: React.FC = () => {
   return (
     <MobileLayout>
-      <Header />
       <RecruitHeader title="컴퓨터 소프트웨어 공학과 전공 동아리 다솜 34기 모집 폼" />
       <RecruitUI />
       <div className=" flex flex-col items-center gap-6">

--- a/src/pages/RecruitMeeting.tsx
+++ b/src/pages/RecruitMeeting.tsx
@@ -36,7 +36,6 @@ const RecruitMeeting: React.FC = () => {
 
 	return (
 		<MobileLayout>
-			<Header />
 			<RecruitHeader title='컴퓨터 소프트웨어 공학과 전공 동아리 다솜 34기 모집 폼' />
 			<RecruitUI />
 			<div className='flex flex-col items-center w-full'>

--- a/src/pages/RecruitSubmitMeeting.tsx
+++ b/src/pages/RecruitSubmitMeeting.tsx
@@ -9,7 +9,6 @@ const RecruitSubmitMeeting: React.FC = () => {
 
 	return (
 		<MobileLayout>
-			<Header />
 			<div className='flex flex-col items-center w-full mt-6'>
 				<p className='font-pretendardBold text-white text-center bg-mainColor w-[90%]'>
 					면접일 제출이 완료되었습니다.


### PR DESCRIPTION
## Issue
- #37 

## 목적
- Header에서 페이지 이동 기능 추가

## 구현 내용
- App.tsx에 route 추가, 페이지 url 설정
- Header에 클릭 이벤트 추가, 페이지 navigate 연결
- DASOM 로고 클릭시 메인 페이지로 이동

## 참고 사항
- Header 컴포넌트 App.tsx로 이동시켰습니다. 다른 페이지들 Header 컴포넌트 삭제했습니다