### PR TITLE
[feat] 합격 조회 페이지 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { RecruitResult } from './pages/RecruitResult'
 import FAQ from './pages/FAQ'
 import { RecruitSubmit } from './pages/RecruitSubmit'
 import RecruitCheck from './pages/RecruitCheck'
+import RecruitCheckFinal from './pages/RecruitCheckFinal'
 
 function App() {
 	return (
@@ -49,6 +50,7 @@ function AppContent() {
 				<Route path='/recruit/submit' element={<RecruitSubmit />} />
 				<Route path='/recruit/result' element={<RecruitResult />} />
 				<Route path='/recruit/check' element={<RecruitCheck />} />
+				<Route path='/recruit/check/final' element={<RecruitCheckFinal />} />
 				<Route path='/recruit/meeting' element={<RecruitMeeting />} />
 				<Route path='/recruit/meeting/submit' element={<RecruitSubmitMeeting />} />
 				<Route path='/admin' element={<AdminMain />} />

--- a/src/components/UI/RecruitUI.tsx
+++ b/src/components/UI/RecruitUI.tsx
@@ -4,6 +4,10 @@ interface RecruitHeaderProps {
   title: string;
 }
 
+interface RecruitUIProps {
+  name: string
+}
+
 export const RecruitHeader: React.FC<RecruitHeaderProps> = ({ title }) => {
   return (
     <div className=" w-full max-w-[375px] bg-[#00B493] text-white font-pretendardBold text-[13px] p-1 pl-2 ml-2.5 mt-16">
@@ -59,7 +63,7 @@ export const RecruitUI: React.FC = () => {
       <div className="mt-2 pl-2">
         <p className="text-green-400 font-pretendardSemiBold">📅 모집 일정 :</p>
         {recruitmentData ? (
-          <p>모집 폼 제출 : {formatDate(recruitmentData.RECRUITMENT_PERIOD_START)} ~ {formatDate(recruitmentData.RECRUITMENT_PERIOD_START)}</p>
+          <p>모집 폼 제출 : {formatDate(recruitmentData.RECRUITMENT_PERIOD_START)} ~ {formatDate(recruitmentData.RECRUITMENT_PERIOD_END)}</p>
         ) : (
           <p>모집 일정 불러오는 중...</p>
         )}
@@ -69,7 +73,7 @@ export const RecruitUI: React.FC = () => {
           <p>대면 일정 불러오는 중...</p>
         )}
         {recruitmentData ? (
-          <p>최종 합격자 발표 : {formatDate(recruitmentData.INTERVIEW_PERIOD_START)}</p>
+          <p>최종 합격자 발표 : {formatDate(recruitmentData.INTERVIEW_PASS_ANNOUNCEMENT)}</p>
         ) : (
           <p>최종 합격 일정 불러오는 중...</p>
         )}
@@ -98,12 +102,12 @@ export const RecruitUI: React.FC = () => {
 }
 
 
-export const RecruitUI_SUB: React.FC = () => {
+export const RecruitUI_SUB: React.FC<RecruitUIProps> = ({name}) => {
   return (
     <div className="whitespace-pre-line text-white flex flex-col items-start max-w-[375px] h-[auto] shadow-[0px_2px_3px_rgba(255,255,255,0.2)] bg-#17171B] gap-2 ml-2.5 font-pretendardRegular pl-2 pr-2 text-[12px] ">
 
       <p className="pt-3 ">
-        {`___님 안녕하세요 컴퓨터공학부 전공동아리 다솜입니다.
+        {`${name}님 안녕하세요 컴퓨터공학부 전공동아리 다솜입니다.
         먼저 다솜 34기에 많은 관심을 갖고 지원해 주셔서 감사드리며, `}
         <p><span className='text-green-400 font-pretendardBold'>1차 서류 합격</span>을 진심으로 축하드립니다!</p>
       </p>
@@ -112,9 +116,77 @@ export const RecruitUI_SUB: React.FC = () => {
         안내드립니다.`}
       </p>
 
-      <p className='mb-10'>{`대면 인터뷰는 3/19(수)~21(금) 중에 진행 될 예정이며 편한 시간대로
-        폼을 작성해주시면 감사하겟습니다.`}</p>
+      <p className='mb-3'>{`대면 인터뷰는 3/12(수)~14(금) 중에 진행 될 예정이며 편한 시간대로
+        폼을 작성해주시면 감사하겠습니다.`}</p>
     </div>
   )
 }
 
+export const RecruitUI_SUB2: React.FC<RecruitUIProps> = ({name}) => {
+  return (
+    <div className="whitespace-pre-line text-white flex flex-col items-start max-w-[375px] h-[auto] shadow-[0px_2px_3px_rgba(255,255,255,0.2)] bg-#17171B] gap-2 ml-2.5 font-pretendardRegular pl-2 pr-2 text-[12px] ">
+
+      <p className="pt-3 ">
+        {`${name}님 안녕하세요 컴퓨터공학부 전공동아리 다솜입니다.
+        먼저 다솜 34기에 많은 관심을 갖고 지원해 주셔서 감사드리며, `}
+      </p>
+
+      <p >{`안타깝게도, 모집 인원 제한으로 인해
+      ${name}님의 1차 서류 결과 불합격을 안내드리게 되었습니다.`}
+      </p>
+
+      <p className='mb-3'>{`좋은 결과를 드리지 못해 아쉬운 마음이 크지만,
+      앞으로도 멋진 기회들이 많을 거라 믿습니다.
+      다시 한번 지원해주셔서 감사드리며, ${name}님의 앞날을 응원하겠습니다.`}</p>
+    </div>
+  )
+}
+
+export const RecruitUI_FINAL: React.FC<RecruitUIProps> = ({name}) => {
+  return (
+    <div className="whitespace-pre-line text-white flex flex-col items-start max-w-[375px] h-[auto] shadow-[0px_2px_3px_rgba(255,255,255,0.2)] bg-#17171B] gap-2 ml-2.5 font-pretendardRegular pl-2 pr-2 text-[12px] ">
+
+      <p className="pt-3 font-pretendardBold ">
+        안녕하세요 {`${name}`}님, <br/> 다솜 34기에<span className='text-green-400 font-pretendardBold'> 최종합격</span> 되신 점 축하드립니다!
+      </p>
+
+      <p >{`길었던 면접 과정 간 고생 많으셨습니다.
+      향후 활동 내용은 디스코드 및 카카오톡 단체 톡방을 통해
+      전달 될 예쩡이며, 카카오톡 단체 톡방은 금일 밤 중 초대드릴 예정입니다.`}
+      </p>
+
+      <p className='mb-3'>
+        {`다시 한번 진심으로 축하드리며,
+        2025학년도 다솜 34기 멤버로서의 앞으로의 활동을 기대하겠습니다.
+        수고 많으셨습니다. ☺️`}
+      </p>
+    </div>
+  )
+}
+
+export const RecruitUI_FINAL2: React.FC<RecruitUIProps> = ({name}) => {
+  return (
+    <div className="whitespace-pre-line text-white flex flex-col items-start max-w-[375px] h-[auto] shadow-[0px_2px_3px_rgba(255,255,255,0.2)] bg-#17171B] gap-2 ml-2.5 font-pretendardRegular pl-2 pr-2 text-[12px] ">
+
+      <p className="pt-3 ">
+        {`${name}님 안녕하세요. 컴퓨터공학부 전공동아리 다솜입니다.
+        먼저, 다솜 34기에 관심을 갖고 지원해 주시고 소중한 시간을 내어
+        대면 인터뷰까지 함께해 주셔서 진심으로 감사드립니다.`}
+      </p>
+
+      <p >{`함께할 수 있기를 기대했지만, 모집 인원 제한으로 인해
+      안타깝게도 ${name}님께 불합격 소식을 전하게 되었습니다.`}
+      </p>
+
+      <p >{`짧은 시간이었지만 ${name}님의 열정과 역량을 볼 수 있어 감사했고,
+      더 좋은 기회에서 빛을 발하실 거라 믿습니다.`}
+      </p>
+
+      <p className='mb-3'>
+        {`다시 한번 지원해 주셔서 감사드리며,
+        앞으로의 모든 도전을 응원하겠습니다.
+        수고 많으셨습니다.`}
+      </p>
+    </div>
+  )
+}

--- a/src/components/UI/Recruit_InputField.tsx
+++ b/src/components/UI/Recruit_InputField.tsx
@@ -50,8 +50,8 @@ export const InputField: React.FC<InputFieldProps> = ({
   return (
     <div className={containerStyles}>
       <label className="block text-white mb-1">
-        {label.split(/(전화번호 마지막 4자리)/).map((part, index) => (
-          <span key={index} className={part === '전화번호 마지막 4자리' ? 'text-[#00B493]' : ''}>
+        {label.split(/(전화번호 마지막 4자리|학번)/).map((part, index) => (
+          <span key={index} className={['전화번호 마지막 4자리', '학번'].includes(part) ? 'text-[#00B493]' : ''}>
             {part}
 
           </span>

--- a/src/pages/RecruitCheck.tsx
+++ b/src/pages/RecruitCheck.tsx
@@ -1,27 +1,21 @@
 import React from 'react'
 import MobileLayout from '../components/layout/MobileLayout'
-import { useNavigate } from 'react-router-dom'
-import { Header } from '../components/UI/Header'
-import { RecruitHeader, RecruitUI_SUB } from '../components/UI/RecruitUI'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { RecruitHeader, RecruitUI_SUB, RecruitUI_SUB2 } from '../components/UI/RecruitUI'
 import { Button } from '../components/UI/Recruit_Button'
 
 
 const RecruitCheck: React.FC = () => {
-
     const navigate = useNavigate()
-
-    const handleSubmit = (e: React.FormEvent) => {
-        e.preventDefault()
-        navigate('/recruit-submit')
-    }
+    const location = useLocation()
+    const {name, isPassed} = location.state as {name:string, isPassed:boolean}
 
     return (
         <MobileLayout>
-            <Header />
             <RecruitHeader title="컴퓨터 소프트웨어 공학과 전공 동아리 다솜 34기 합격자 조회" />
-            <RecruitUI_SUB />
+            {isPassed? <RecruitUI_SUB name={name}/> : <RecruitUI_SUB2 name={name}/>}
             <div className='mt-5'>
-            <Button text="예약하기" />
+                {isPassed? <Button text='예약하기' onClick={()=> {navigate('/recruit/meeting')}}/>: <Button text='메인으로 돌아가기' onClick={()=> {navigate('/')}}/>}
             </div>
         </MobileLayout>
     )

--- a/src/pages/RecruitCheckFinal.tsx
+++ b/src/pages/RecruitCheckFinal.tsx
@@ -1,0 +1,20 @@
+import MobileLayout from '../components/layout/MobileLayout'
+import React from 'react'
+import { useLocation } from 'react-router-dom'
+import { RecruitHeader, RecruitUI_FINAL, RecruitUI_FINAL2 } from '../components/UI/RecruitUI'
+
+const RecruitChekFinal: React.FC = () => {
+	const location = useLocation()
+    const {name, isPassed} = location.state as {name:string, isPassed:boolean}
+
+	return (
+		<MobileLayout>
+			<RecruitHeader title='컴퓨터 소프트웨어 공학과 전공 동아리 다솜 34기 합격자 조회' />
+			{isPassed? <RecruitUI_FINAL name={name}/> : <RecruitUI_FINAL2 name={name}/> }
+			<div className='mt-5'>
+			</div>
+		</MobileLayout>
+	)
+}
+
+export default RecruitChekFinal

--- a/src/pages/RecruitResult.tsx
+++ b/src/pages/RecruitResult.tsx
@@ -40,7 +40,7 @@ export const RecruitResult: React.FC = () => {
 				const interviewPass = new Date(response.data.find((item) => item.key === 'INTERVIEW_PASS_ANNOUNCEMENT')?.value.substring(0, 10) || '')
 				const documentPass = new Date(response.data.find((item) => item.key === 'DOCUMENT_PASS_ANNOUNCEMENT')?.value.substring(0, 10) || '')
 				const today = new Date()
-				console.log(response.data)
+				//console.log(response.data)
 
         // 현재 날짜에 따른 조회 type 지정
 				if (today >= interviewPass) {
@@ -70,8 +70,7 @@ export const RecruitResult: React.FC = () => {
 					contactLastDigit: checkInput.contact,
 				},
 			})
-			console.log(response.data)
-			console.log(response.data.isPassed)
+			//console.log(response.data)
 			const resData: responseData = {
 				name: response.data.name,
 				isPassed: response.data.isPassed,

--- a/src/pages/RecruitResult.tsx
+++ b/src/pages/RecruitResult.tsx
@@ -1,39 +1,110 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import MobileLayout from '../components/layout/MobileLayout'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '../components/UI/Recruit_Button'
 import { RecruitHeader } from '../components/UI/RecruitUI'
 import { InputField } from '../components/UI/Recruit_InputField'
+import axios from 'axios'
 
-export const RecruitResult: React.FC = () => {
-  const navigate = useNavigate()
-  const [checkInput, setCheckInput] = useState('')
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
-    setCheckInput(e.target.value)
-  }
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    navigate('/recruit-check')
-  }
-
-  return (
-    <MobileLayout>
-      <RecruitHeader title="컴퓨터 소프트웨어 공학과 전공 동아리 다솜 34기 합격자 조회" />
-      <form className="mt-4 bg-mainBlack w-full px-2" onSubmit={handleSubmit}>
-        <InputField
-          label="학번 마지막 4자리 + 전화번호 마지막 4자리를 입력해주세요."
-          subLabel="ex) 08470542"
-          type="text"
-          name="checkInput"
-          value={checkInput}
-          onChange={handleInputChange}
-        />
-        <Button text="결과 확인하기" />
-      </form>
-    </MobileLayout>
-  )
+interface recruitData {
+	key: string
+	value: string
 }
 
+interface responseData {
+	name: string
+	isPassed: boolean
+}
 
+export const RecruitResult: React.FC = () => {
+	const navigate = useNavigate()
+	const [checkInput, setCheckInput] = useState({
+		studentNo: '',
+		contact: '',
+	})
+	const [pass, setPass] = useState<string | null>()
+
+	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+		const { name, value } = e.target
+		setCheckInput((prevState) => ({
+			...prevState,
+			[name]: value,
+		}))
+	}
+
+  // 합격여부 조회 일정 확인 후 검색 type 지정
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				const response = await axios.get<recruitData[]>('https://dmu-dasom.or.kr/api/recruit')
+				const interviewPass = new Date(response.data.find((item) => item.key === 'INTERVIEW_PASS_ANNOUNCEMENT')?.value.substring(0, 10) || '')
+				const documentPass = new Date(response.data.find((item) => item.key === 'DOCUMENT_PASS_ANNOUNCEMENT')?.value.substring(0, 10) || '')
+				const today = new Date()
+				console.log(response.data)
+
+        // 현재 날짜에 따른 조회 type 지정
+				if (today >= interviewPass) {
+					setPass('INTERVIEW_PASS')
+				} else if (today >= documentPass) {
+					setPass('DOCUMENT_PASS')
+				} else {
+          alert('합격 발표일이 아닙니다')
+        }
+			} catch(e) {
+        console.log(e)
+        alert('발표 일정을 조회할 수 없습니다')
+      }
+		}
+    fetchData()
+	}, [])
+
+	// 합격 여부 조회 후 페이지 이동
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault()
+
+		try {
+			const response = await axios.get('https://dmu-dasom.or.kr/api/recruit/result', {
+				params: {
+					type: pass, // 현재 날짜에 따른 검색 type
+					studentNo: checkInput.studentNo,
+					contactLastDigit: checkInput.contact,
+				},
+			})
+			console.log(response.data)
+			console.log(response.data.isPassed)
+			const resData: responseData = {
+				name: response.data.name,
+				isPassed: response.data.isPassed,
+			}
+
+      // 조회 type에 따라 이동 url 다르게 
+			navigate(`/recruit/${pass === 'DOCUMENT_PASS' ? 'check' :'check/final' }`, {
+				state: {
+					name: resData.name,
+					isPassed: resData.isPassed,
+				},
+			})
+		} catch (e) {
+			console.log(e)
+			alert('데이터 검색 불가')
+		}
+	}
+
+	return (
+		<MobileLayout>
+			<RecruitHeader title='컴퓨터 소프트웨어 공학과 전공 동아리 다솜 34기 합격자 조회' />
+			<form className='mt-4 bg-mainBlack w-full px-2' onSubmit={handleSubmit}>
+				<InputField
+					label='지원하실때 입력하셨던 학번을 입력해주세요.'
+					subLabel='ex) 20250001'
+					type='text'
+					name='studentNo'
+					value={checkInput.studentNo}
+					onChange={handleInputChange}
+				/>
+				<InputField label='전화번호 마지막 4자리를 입력해주세요.' subLabel='ex) 0542' type='text' name='contact' value={checkInput.contact} onChange={handleInputChange} />
+				<Button text='결과 확인하기' />
+			</form>
+		</MobileLayout>
+	)
+}


### PR DESCRIPTION
# [feat] 합격 조회 페이지 API 연동

## Issue
- #79 

## 변경 내용
- 합격 조회 페이지 API 연동
- 최종 합격 페이지 추가
- RecruitUI_FINAL 컴포넌트 추가
- 학번과 전화번호 뒷자리 입력으로 변경 

## 상세 내용
- 현재 시간을 기준으로 서버에 저장된 합격 조회 날짜를 비교하여 1차합격, 2차합격 조회 할 수 있도록 하였습니다
- 조회된 지원자의 합격 여부에 따라 컴포넌트 출력하게끔 했습니다