### PR TITLE
[fix] RecruitResult 호출 수정 & onKeyDown 추가, InputField 중복 수정

### DIFF
--- a/src/components/UI/Recruit_InputField.tsx
+++ b/src/components/UI/Recruit_InputField.tsx
@@ -34,7 +34,6 @@ export const InputField: React.FC<InputFieldProps> = ({
 
 }) => {
 
-  // textarea 크기 변환환
   const handleTextAreaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     e.target.style.height = 'auto'
     e.target.style.height = `${e.target.scrollHeight}px`
@@ -49,9 +48,15 @@ export const InputField: React.FC<InputFieldProps> = ({
     <div className={containerStyles}>
       <label className="block text-white mb-1">
         {label.split(/(전화번호 마지막 4자리|학번)/).map((part, index) => (
-          <span key={index} className={['전화번호 마지막 4자리', '학번'].includes(part) ? 'text-[#00B493]' : ''}>
+          <span
+            key={index}
+            className={
+              ['전화번호 마지막 4자리', '학번'].includes(part) && subLabel === 'ex) 20250001'
+                ? 'text-[#00B493]'
+                : ''
+            }
+          >
             {part}
-
           </span>
         ))}
         {required && <span className="text-[#C11100] pl-1">*</span>}


### PR DESCRIPTION
# [fix] RecruitResult 호출 수정 & onKeyDown 추가, InputField 중복 수정

## Issue
- #89 

## 변경 내용
- Recruit_InputField  컴포넌트에 라벨을 기준으로 텍스트 색상 변경
-  RecruitResult 페이지 버튼을 클릭시 합격 발표날 기준 참인지 거짓인지 따라 alert 호출 & onKeyDown을 추가

## 상세 내용
- 기존 Recruit_InputField에 subLabel 값을 기준으로 텍스트 색깔 지정
-  RecruitResult 페이지 합격 발표일 아닐 경우만 alert를 실행하는거에서 학번과 전화번호 둘 중 하나라도 입력을 안할 시 각각의 alert 텍스트 내용을 출력하게 기능추가  
 ``` tsx 
	alert('학번을 입력해주세요.')

	alert('전화번호 마지막 4자리를 입력해주세요.')
	
	alert('합격 발표일이 아닙니다.')
```