### PR TITLE
[feat] 어드민 공지사항 API 연동 완료

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import ManApplicants from './pages/admin/ManApplicants'
 import ManNewsList from './pages/admin/ManNewsList'
 import ManNewsDetail from './pages/admin/ManNewsDetail'
 import ManNewsPost from './pages/admin/ManNewsPost'
+import ManNewsEdit from './pages/admin/ManNewsEdit'
 import ManRecruitDate from './pages/admin/ManRecruitDate'
 import UserMain from './pages/UserMain'
 import Recruit from './pages/Recruit'
@@ -65,6 +66,7 @@ function AppContent() {
         		<Route path='/admin/news' element={<ProtectedRoute><ManNewsList /></ProtectedRoute>} />
 				<Route path='/admin/news/:no' element={<ProtectedRoute><ManNewsDetail /></ProtectedRoute>} />
 				<Route path='/admin/news/post' element={<ProtectedRoute><ManNewsPost /></ProtectedRoute>} />
+				<Route path='/admin/news/edit/:no' element={<ProtectedRoute><ManNewsEdit /></ProtectedRoute>} />
 			</Routes>
 		</>
 	)

--- a/src/components/UI/NewsFileUpload.tsx
+++ b/src/components/UI/NewsFileUpload.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+
+interface FileUploadProps {
+    files: File[]
+    setFiles: React.Dispatch<React.SetStateAction<File[]>>
+}
+
+const NewsFileUpload: React.FC<FileUploadProps> = ({ files, setFiles }) => {
+    const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (e.target.files) {
+            const selectedFiles = Array.from(e.target.files)
+            setFiles((prevFiles) => [...prevFiles, ...selectedFiles])
+        }
+    }
+
+    const handleFileRemove = (index: number) => {
+        setFiles((prevFiles) => prevFiles.filter((_, i) => i !== index))
+    }
+
+    return (
+        <div className='mb-16'>
+            <label className='block mt-4 mb-1'>이미지 첨부</label>
+            <input
+                type='file'
+                multiple
+                onChange={handleImageChange}
+                className='mb-3'
+            />
+
+            <div className='mb-4'>
+                <div className='mb-2'>업로드 된 파일 목록</div>
+                {Array.isArray(files) && files.length > 0 ? ( 
+                    files.map((file, index) => (
+                        <div key={index} className='text-white cursor-pointer' onClick={() => handleFileRemove(index)}>
+                            {file.name}
+                        </div>
+                    ))
+                ) : (
+                    <div className='text-[14px]'>새로 업로드된 파일이 없습니다.</div>
+                )}
+            </div>
+        </div>
+    )
+}
+
+export default NewsFileUpload

--- a/src/components/UI/NewsTextEditor.tsx
+++ b/src/components/UI/NewsTextEditor.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+
+interface TextEditorProps {
+    title: string
+    content: string
+    setTitle: React.Dispatch<React.SetStateAction<string>>
+    setContent: React.Dispatch<React.SetStateAction<string>>
+}
+
+const NewsTextEditor: React.FC<TextEditorProps> = ({ title, content, setTitle, setContent }) => {
+    const autoResizeTextarea = (e: React.FormEvent<HTMLTextAreaElement>) => {
+        const textarea = e.target as HTMLTextAreaElement
+        textarea.style.height = 'auto'
+        textarea.style.height = `${textarea.scrollHeight}px`
+    }
+
+    const applyFormat = (tag: string, style?: string) => {
+        const formattedText = style
+            ? `<span style='${style}'></span>`
+            : `<${tag}></${tag}>`
+
+        setContent((prev) => prev + formattedText)
+    }
+
+    return (
+        <div className='w-[1220px] font-pretendardRegular'>
+
+            <label className='block mb-2'>제목</label>
+            <textarea
+                className='text-black w-full p-2 border rounded-[6px] mb-4'
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder='제목을 입력하세요'
+            />
+
+            <div className='flex justify-between w-[1220px]'>
+                <div className='w-[600px]'>
+                    <label className='block mb-2'>내용</label>
+                    <textarea
+                        className="text-black w-full p-2 border rounded-[6px] mb-4"
+                        value={content}
+                        onChange={(e) => setContent(e.target.value)}
+                        placeholder="내용을 입력하세요"
+                        onInput={autoResizeTextarea}
+                    />
+                    <div className='text-black mb-4 space-x-2'>
+                        <button onClick={() => applyFormat('b')} className='bg-gray-200 px-2 py-1 rounded-[6px]'>굵게</button>
+                        <button onClick={() => applyFormat('span', 'color:#00B493')} className='bg-gray-200 text-mainColor px-2 py-1 rounded-[6px]'>다솜색(#00B493)</button>
+                    </div>
+                </div>
+
+                {/* 미리보기 화면 */}
+                <div className='mb-[20px] w-[600px]'>
+                    <div className='block mb-2'>미리보기</div>
+                    <div
+                        className='text-white p-4 border rounded-[6px] bg-gray-800 break-words'
+                        dangerouslySetInnerHTML={{
+                            __html: content.replace(/\n/g, '<br />'), // <br />로 줄바꿈 처리
+                        }}
+                    />
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default NewsTextEditor

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -15,7 +15,7 @@ const Login: React.FC = () => {
         }
         
         try {
-            const response = await axios.post('https://dmu-dasom.or.kr/api/auth/login', {
+            const response = await axios.post('https://dmu-dasom-api.or.kr/api/auth/login', {
                 email,
                 password
             })

--- a/src/pages/admin/AdminMain.tsx
+++ b/src/pages/admin/AdminMain.tsx
@@ -22,7 +22,7 @@ const AdminMain: React.FC = () => {
     const handleLogout = async () => {
         try {
             // 로그아웃
-            await axios.post('https://dmu-dasom.or.kr/api/auth/logout', {}, {
+            await axios.post('https://dmu-dasom-api.or.kr/api/auth/logout', {}, {
                 headers: {
                     'Authorization': `Bearer ${localStorage.getItem('accessToken')}`
                 }

--- a/src/pages/admin/ManApplicants.tsx
+++ b/src/pages/admin/ManApplicants.tsx
@@ -45,7 +45,7 @@ const ManApplicants: React.FC = () => {
                     return
                 }
         
-                const response = await axios.get('https://dmu-dasom.or.kr/api/admin/applicants', {
+                const response = await axios.get('https://dmu-dasom-api.or.kr/api/admin/applicants', {
                     headers: {
                         Authorization: `Bearer ${accessToken}`
                     }
@@ -76,7 +76,7 @@ const ManApplicants: React.FC = () => {
         }
     
         try {
-            const response = await axios.get(`https://dmu-dasom.or.kr/api/admin/applicants/${id}`, {
+            const response = await axios.get(`https://dmu-dasom-api.or.kr/api/admin/applicants/${id}`, {
                 headers: {
                     Authorization: `Bearer ${accessToken}`
                 }
@@ -105,7 +105,7 @@ const ManApplicants: React.FC = () => {
         )
         setOpenDropdownId(null) // 드롭다운 닫기
 
-        axios.patch(`https://dmu-dasom.or.kr/api/admin/applicants/${id}/status`, { status: statusValue }, {
+        axios.patch(`https://dmu-dasom-api.or.kr/api/admin/applicants/${id}/status`, { status: statusValue }, {
             headers: { Authorization: `Bearer ${accessToken}` }
         })
         .then(() => {

--- a/src/pages/admin/ManNewsDetail.tsx
+++ b/src/pages/admin/ManNewsDetail.tsx
@@ -3,24 +3,32 @@ import MobileLayout from '../../components/layout/MobileLayout'
 import { useParams, useNavigate } from 'react-router-dom'
 import axios from 'axios'
 
+interface Image {
+    id: number
+    fileFormat: string
+    encodedData: string
+}
+
 interface News {
     id: string
     title: string
     content: string
     createdAt: string
-    imageUrl?: string
+    images: Image[]
 }
 
 const ManNewsDetail: React.FC = () => {
     const { no } = useParams<{ no: string }>()
     const [news, setNews] = useState<News | null>(null)
+    const [images, setImages] = useState<Image[]>([])
     const navigate = useNavigate()
 
     useEffect(() => {
         const fetchNews = async () => {
             try {
-                const response = await axios.get<News>(`https://dmu-dasom.or.kr/api/news/${no}`)
+                const response = await axios.get<News>(`https://dmu-dasom-api.or.kr/api/news/${no}`)
                 setNews(response.data)
+                setImages(response.data.images)
                 console.log(response.data)
             } catch (err) {
                 console.error('Error fetching news:', err)
@@ -32,7 +40,7 @@ const ManNewsDetail: React.FC = () => {
     const handleDelete = async () => {
         if (window.confirm('정말 삭제하시겠습니까?')) {
             try {
-                await axios.delete(`https://dmu-dasom.or.kr/api/news/${no}`)
+                await axios.delete(`https://dmu-dasom-api.or.kr/api/news/${no}`)
                 alert('삭제되었습니다.')
                 navigate('/admin/news') // 삭제 후 목록 페이지로 이동
             } catch (err) {
@@ -48,7 +56,7 @@ const ManNewsDetail: React.FC = () => {
                 <div className='mt-[80px] mb-[20px] mr-[20px] flex justify-end'>
                     <div 
                         className='cursor-pointer border border-gray-600 px-2 py-1 rounded-[6px] bg-gray-800 hover:bg-gray-900 mr-[8px]'
-                        //onClick={}
+                        onClick={() => navigate(`/admin/news/edit/${no}`)}
                     >
                         수정
                     </div>
@@ -61,10 +69,26 @@ const ManNewsDetail: React.FC = () => {
                 </div>
             
                 <div>
-                    <h1>{news?.title}</h1>
-                    <p>{news?.createdAt ? new Date(news.createdAt).toLocaleDateString() : ''}</p>
-                    {news?.imageUrl && <img src={news.imageUrl} alt={news.title} />}
-                    <p>{news?.content}</p>
+                    <div>{news?.title}</div>
+                    <div>{news?.createdAt ? new Date(news.createdAt).toLocaleDateString() : ''}</div>
+                    {Array.isArray(images) && images.length > 0 ? ( // 이미지가 있을 때만 렌더링
+                        images.map((image) => (
+                            <div key={image.id} className="flex items-center">
+                                <img
+                                    src={`data:${image.fileFormat};base64,${image.encodedData}`}
+                                    alt={`image-${image.id}`}
+                                    className="w-max h-auto object-cover"
+                                />
+                            </div>
+                        ))
+                    ) : (
+                        <div className='text-[14px]'>업로드된 파일이 없습니다.</div>
+                    )}
+                    <div
+                        dangerouslySetInnerHTML={{
+                            __html: news?.content || ''
+                        }}
+                    />
                 </div>
             </MobileLayout>
         </div>

--- a/src/pages/admin/ManNewsEdit.tsx
+++ b/src/pages/admin/ManNewsEdit.tsx
@@ -1,0 +1,156 @@
+import React, { useState, useEffect } from 'react'
+import axios from 'axios'
+import { useNavigate, useParams } from 'react-router-dom'
+import NewsFileUpload from '../../components/UI/NewsFileUpload'
+import NewsTextEditor from '../../components/UI/NewsTextEditor'
+
+interface Image {
+    id: number
+    fileFormat: string
+    encodedData: string
+}
+
+interface News {
+    id: string
+    title: string
+    content: string
+    createdAt: string
+    images: Image[]
+}
+
+const ManNewsEdit: React.FC = () => {
+    const [title, setTitle] = useState('')
+    const [content, setContent] = useState('')
+    const [images, setImages] = useState<Image[]>([]) // 기존 업로드된 파일들
+    const [files, setFiles] = useState<File[]>([]) // 새로 첨부된 파일들
+    const [deleteImageIds, setDeleteImageIds] = useState<number[]>([])
+    const { no } = useParams<{ no: string }>()
+    const navigate = useNavigate()
+
+    useEffect(() => {
+        const fetchNews = async () => {
+            try {
+                const response = await axios.get<News>(`https://dmu-dasom-api.or.kr/api/news/${no}`)
+                const { title, content, images } = response.data
+                setTitle(title)
+                setContent(content)
+                setImages(images)
+            } catch (error) {
+                console.error('소식 불러오기 오류:', error)
+                alert('소식을 불러오는 중 오류가 발생했습니다.')
+            }
+        }
+
+        if (no) fetchNews()
+    }, [no])
+
+    // 이미지 삭제 목록에 추가 (기존 업로드된 파일 목록에서)
+    const handleImageDelete = (imageId: number) => {
+        setDeleteImageIds((prev) => [...prev, imageId])
+        setImages(prevImages => prevImages.filter(image => image.id !== imageId))
+    }
+
+    // 수정 완료 버튼
+    const handleSubmit = async () => {
+        if (!title.trim() || !content.trim()) {
+            alert('제목과 내용을 모두 입력해주세요.')
+            return
+        }
+
+        try {
+            const token = localStorage.getItem('accessToken')
+            
+            // 뉴스 수정 요청
+            const updateResponse = await axios.put(
+                `https://dmu-dasom-api.or.kr/api/news/${no}`,
+                {
+                    title,
+                    content: content.replace(/\n/g, '<br />'),
+                    deleteImageIds,
+                },
+                {
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        'Content-Type': 'application/json',
+                    },
+                }
+            )
+            console.log({
+                title,
+                content: content.replace(/\n/g, '<br />'),
+                deleteImageIds,
+            })
+
+
+            const newsId = updateResponse.data.id
+
+            // 새로 첨부된 파일들 업로드
+            const formData = new FormData()
+            files.forEach((file) => formData.append('files', file))
+            formData.append('fileType', 'NEWS')
+            formData.append('targetId', newsId)
+
+            if (files.length > 0) { // 첨부된 파일이 있을 때만 업로드
+                await axios.post('https://dmu-dasom-api.or.kr/api/files/upload', formData, {
+                    headers: {
+                        'Authorization': `Bearer ${token}`,
+                        'Content-Type': 'multipart/form-data',
+                    },
+                })
+            }
+            alert('소식이 성공적으로 수정되었습니다.')
+            navigate(`/admin/news/${no}`)
+        } catch (error) {
+            console.error('소식 수정 오류:', error)
+            alert('소식 수정 중 오류가 발생했습니다.')
+        }
+    }
+
+    return (
+        <div className='h-[100vh] w-[100vw] bg-mainBlack font-pretendardRegular text-white flex flex-col items-center overflow-auto'>
+            <div className='flex justify-between w-[1220px] mt-[155px] mb-[12px] font-pretendardSemiBold'>
+                <div className='text-[20px]'>소식 수정</div>
+                <button
+                    onClick={handleSubmit}
+                    className='bg-mainColor text-white px-4 py-1 rounded-[6px] hover:bg-teal-700'>
+                    수정 완료
+                </button>
+            </div>
+
+            <div className='flex flex-col w-[1220px]'>
+
+                {/* 제목 및 내용텍스트 편집 */}
+                <NewsTextEditor 
+                    title={title} 
+                    content={content} 
+                    setTitle={setTitle} 
+                    setContent={setContent} 
+                />
+
+                <div className="mt-8 mb-4">
+                    <div className='mb-2'>기존 업로드 파일 목록</div>
+                    {Array.isArray(images) && images.length > 0 ? ( // 이미지가 있을 때만 렌더링
+                        images.map((image) => (
+                            <div key={image.id} className="flex items-center">
+                                <img
+                                    src={`data:${image.fileFormat};base64,${image.encodedData}`}
+                                    alt={`image-${image.id}`}
+                                    className="w-24 h-auto object-cover"
+                                />
+                                <button
+                                    onClick={() => handleImageDelete(image.id)}
+                                    className="ml-2 text-red-500">삭제</button>
+                            </div>
+                        ))
+                    ) : (
+                        <div className='text-[14px]'>업로드된 파일이 없습니다.</div>
+                    )}
+                </div>
+
+                <NewsFileUpload files={files} setFiles={setFiles} />
+            </div>
+        </div>
+    )
+}
+
+export default ManNewsEdit

--- a/src/pages/admin/ManNewsList.tsx
+++ b/src/pages/admin/ManNewsList.tsx
@@ -23,7 +23,7 @@ const ManNewsList: React.FC = () => {
     useEffect(() => {
         const fetchData = async () => {
             try {
-                const response = await axios.get('https://dmu-dasom.or.kr/api/news')
+                const response = await axios.get('https://dmu-dasom-api.or.kr/api/news')
                 const formattedData = response.data.map((item: any) => ({
                     id: item.id,
                     title: item.title,

--- a/src/pages/admin/ManRecruitDate.tsx
+++ b/src/pages/admin/ManRecruitDate.tsx
@@ -46,7 +46,7 @@ const ManRecruitDate = () => {
     useEffect(() => {
         const fetchDates = async () => {
             try {
-                const response = await axios.get('https://dmu-dasom.or.kr/api/recruit')
+                const response = await axios.get('https://dmu-dasom-api.or.kr/api/recruit')
                 const data = response.data
                 const defaultDates = dates
 
@@ -93,7 +93,7 @@ const ManRecruitDate = () => {
         console.log(token)
     
         try {
-            await axios.patch('https://dmu-dasom.or.kr/api/admin/recruit/schedule', formattedData, {
+            await axios.patch('https://dmu-dasom-api.or.kr/api/admin/recruit/schedule', formattedData, {
                 headers: {
                     'Authorization': `Bearer ${token}`,
                     'Content-Type': 'application/json'


### PR DESCRIPTION
# [feat] 어드민 공지사항 API 연동 완료

## Issue
- #56 

## 변경 내용
- 어드민 공지사항 수정 및 등록 api 연결했습니다.

## 구현 사항
- api 주소 수정 ( 어드민 페이지 전체, 로그인페이지)
- api 연동하고 컴퍼넌트 분리할 수 있는 거 두개 정도 분리해서 ui 폴더에 넣었습니다
- 어드민에서 뉴스 상세페이지 css는 아직 안넣었습니다 (태우님꺼 머지되는 대로 수정하겠습니다.)
  - 제목, 등록날짜, 이미지나열 정도로 내용만 확인할 수 있게 해놨습니다 
