### PR TITLE
[feat] news 페이지,상세페이지 api 연동 & 스와이퍼 아이콘 커스텀 스타일 변경

### DIFF
--- a/src/assets/styles/index.css
+++ b/src/assets/styles/index.css
@@ -108,3 +108,22 @@
       scrollbar-width: none;  /* Firefox */
     }
   }
+
+
+
+.swiper-pagination-bullet {
+  width: 5px;
+  height: 5px;
+  background-color: #ffffffff !important;
+  opacity: 0.6;
+  border: 2px solid white;
+  transition: all 0.3s ease;
+}
+
+.swiper-pagination-bullet-active {
+  width: 5px;
+  height: 5px;
+  background-color: white; 
+  transform: scale(1.3); 
+}
+

--- a/src/components/UI/NewsNotice.tsx
+++ b/src/components/UI/NewsNotice.tsx
@@ -2,14 +2,12 @@ import React, { JSX } from 'react'
 
 interface notice {
 	text: string
-	date: Date
 }
 
-const NewsNotice = ({ text, date }: notice): JSX.Element => {
+const NewsNotice = ({ text }: notice): JSX.Element => {
 	return (
-		<div className='w-[90%] mb-5'>
-			<div className='text-white font-pretendardRegular whitespace-pre-wrap' dangerouslySetInnerHTML={{ __html: text }} />
-			<p className='text-subGrey2 font-pretendardRegular mt-5'>작성일 : {date.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' })}</p>
+		<div className='w-[100%] font-pretendardRegular text-[12px] mb-5'>
+			<div className='text-white whitespace-pre-wrap' dangerouslySetInnerHTML={{ __html: text }} />
 		</div>
 	)
 }

--- a/src/pages/News.tsx
+++ b/src/pages/News.tsx
@@ -1,43 +1,91 @@
-import React from 'react'
+import React, { useEffect, useState, useRef, useMemo } from 'react'
 import MobileLayout from '../components/layout/MobileLayout'
 import dasomLogo from '../assets/images/dasomLogo.svg'
 import NewsContent from '../components/UI/NewsContent'
 import { useNavigate } from 'react-router-dom'
 
-interface news {
-	id: number // 고유번호
-	title: string // 제목
-	banner: string | null // 배너 이미지
-	date: string // 기간
+interface ImageData {
+	encodedData: string
+	fileFormat: string
 }
 
-/** 예시 데이터 */
-const newsContentExam: news[] = [
-	{ id: 1, title: '다솜 34기 신규 부원 모집!', banner: null, date: '2월 25일(화) ~ 3월 14일(금)' },
-	{ id: 2, title: '다솜 34기 신규 부원 모집!', banner: null, date: '2월 25일(화) ~ 3월 14일(금)' },
-	{ id: 3, title: '다솜 34기 신규 부원 모집!', banner: null, date: '2월 25일(화) ~ 3월 14일(금)' },
-	{ id: 4, title: '다솜 34기 신규 부원 모집!', banner: null, date: '2월 25일(화) ~ 3월 14일(금)' },
-]
+interface NewsItem {
+	id: number
+	title: string
+	image: ImageData | null
+	createdAt: string
+}
 
-/** 소식 페이지 */
 const News: React.FC = () => {
 	const navigate = useNavigate()
+	const [newsList, setNewsList] = useState<NewsItem[]>([])
+	const isFetched = useRef(false)
 
-	// 데이터의 id를 받아와 해당 상세 페이지로 이동
-	const handleClick = (id: number) => {
-		navigate(`/news/${id}`)
+	const fetchNews = async () => {
+		try {
+			// sessionStorage에서 뉴스 데이터 확인
+			const cachedData = sessionStorage.getItem('newsList')
+			if (cachedData) {
+				setNewsList(JSON.parse(cachedData))
+				return
+			}
+
+			const response = await fetch('https://dmu-dasom-api.or.kr/api/news')
+			if (!response.ok) {
+				throw new Error(`API 오류: ${response.status}`)
+			}
+			const data: NewsItem[] = await response.json()
+			console.log('API 응답 데이터:', data)
+
+
+			const sortedData = data.map(item => ({
+				...item,
+				no: item.id 
+			})).sort((a, b) => a.no - b.no)
+			setNewsList(sortedData)
+			sessionStorage.setItem('newsList', JSON.stringify(sortedData))
+		} catch (error) {
+			console.error('뉴스 데이터를 불러오는 중 오류 발생:', error)
+		}
 	}
+
+	useEffect(() => {
+		if (!isFetched.current) {
+			fetchNews()
+			isFetched.current = true
+		}
+	}, [])
+
+	// `useMemo`로 이미지 변환 최적화 (불필요한 연산 방지)
+	const formattedNewsList = useMemo(
+		() =>
+			newsList.map((news) => ({
+				...news,
+				imageUrl:
+					news.image && news.image.encodedData
+						? `data:${news.image.fileFormat};base64,${news.image.encodedData}`
+						: null,
+			})),
+		[newsList]
+	)
 
 	return (
 		<MobileLayout>
-			<div className='mt-[65px] mb-2 ml-[12px] flex'>
+			<div className='mt-[65px] mb-2 px-[12px] flex'>
 				<img className='w-[21px] h-[24px] cursor-pointer' alt='logo' src={dasomLogo} />
 				<div className='font-pretendardSemiBold text-white text-[16px] ml-[9px]'>다솜 소식</div>
 			</div>
-			<div className='flex flex-col items-center w-full mb-40'>
-				{/* 공지사항 리스트 출력 */}
-				{newsContentExam.map((news) => (
-					<NewsContent key={news.id} {...news} onClick={() => handleClick(news.id)} />
+
+			<div className='flex flex-col mx-[12px] w-auto mb-40'>
+				{formattedNewsList.map((news) => (
+					<NewsContent
+						key={news.id}
+						id={news.id}
+						title={news.title}
+						image={news.imageUrl}
+						createdAt={news.createdAt}
+						onClick={() => navigate(`/news/${news.id}`)}
+					/>
 				))}
 			</div>
 		</MobileLayout>


### PR DESCRIPTION
# [feat] news 페이지,상세페이지 api 연동 & 스와이퍼 아이콘 커스텀 스타일 변경

## Issue
- #90 

## 변경 내용 
- news 페이지와 상세페이지 api연결
- 렌더링 최신화
-  Swiper 컴포넌트 추가 및 아이콘 색깔 커스텀 적용

## 구현 사항 
-   sessionStorage 추가하여 데이터를 저장, 렌더링 속도 최적화 및 리렌더링 방지
-  레이아웃 크기 조절 양옆에 mx-[16px] 적용 
-   api 연동 Base64 → 이미지 URL 변환 
-  기존 정적코드 부분 제거 