### PR TITLE
[feat] 면접 예약 페이지 API 연동 - 2

### DIFF
--- a/src/components/UI/MeetingDate.tsx
+++ b/src/components/UI/MeetingDate.tsx
@@ -1,18 +1,24 @@
 import React, { JSX } from 'react'
 
 interface props {
-	month: string
-	day: string
-	week: string
+	date: string
 	onClick?: () => void
 	isSelected?: boolean // 선택 여부 
 }
 
+const getDisplatyDate = (date:string) => {
+	const d = new Date(date)
+	const month = (d.getMonth() + 1).toString()
+	const day = d.getDate().toString()
+	const week = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'][d.getDay()]
+    return `${month}.${day} ${week}`
+}
+
 // 면접 날짜 선택 여부 컴포넌트 
-const MeetingDate = ({ month, day, week, onClick, isSelected }: props): JSX.Element => {
+const MeetingDate = ({ date, onClick, isSelected }: props): JSX.Element => {
 	return (
 		<button className={`font-pretendardBold text-white text-center border-2 border-mainColor p-1 w-[100px] h-[35px] transition-all hover:bg-[#00937A] active:scale-95 ${isSelected ? 'bg-mainColor' : 'bg-none'}`} onClick={onClick}>
-			{month}.{day} {week}
+			{getDisplatyDate(date)}
 		</button>
 	)
 }

--- a/src/components/UI/MeetingDate.tsx
+++ b/src/components/UI/MeetingDate.tsx
@@ -11,7 +11,7 @@ interface props {
 // 면접 날짜 선택 여부 컴포넌트 
 const MeetingDate = ({ month, day, week, onClick, isSelected }: props): JSX.Element => {
 	return (
-		<button className={`font-pretendardBold text-white text-center border-2 border-mainColor p-1 w-[100px] h-[35px] ${isSelected ? 'bg-mainColor' : 'bg-none'}`} onClick={onClick}>
+		<button className={`font-pretendardBold text-white text-center border-2 border-mainColor p-1 w-[100px] h-[35px] transition-all hover:bg-[#00937A] active:scale-95 ${isSelected ? 'bg-mainColor' : 'bg-none'}`} onClick={onClick}>
 			{month}.{day} {week}
 		</button>
 	)

--- a/src/components/UI/MeetingDateSelector.tsx
+++ b/src/components/UI/MeetingDateSelector.tsx
@@ -1,12 +1,6 @@
 import React, { JSX, useEffect, useState } from 'react'
 import MeetingDate from './MeetingDate'
 
-interface dateInfo {
-	month: string
-	day: string
-	week: string
-}
-
 interface interviewPeriod {
 	periodStart: string
 	periodEnd: string
@@ -20,7 +14,7 @@ interface props {
 // 면접 날짜 선택 레이아웃 
 const MeetingDateSelector = ({ onSelect, period }: props): JSX.Element => {
 	const [selectedDate, setSelectedDate] = useState<string>('')
-	const [meetingDates, setMeetingDates] = useState<dateInfo[]>([])
+	const [meetingDates, setMeetingDates] = useState<string[]>([])
 	
 	// 날짜 사이에 일 수 계산
 	const getDateDiff = (d1: string, d2: string) => {
@@ -31,21 +25,21 @@ const MeetingDateSelector = ({ onSelect, period }: props): JSX.Element => {
 
 			return Math.abs(diffDate / (1000 * 60 * 60 * 24))
 	}
+	
+	const getFormattedDate = (date: Date) => {
+		return date.toISOString().split('T')[0]
+	}
 
 	// 면접 예약 일자 목록 가져오기
 	useEffect(() => {
 		const startDate = new Date(period.periodStart)
-		const dateArray: dateInfo[] = []
+		const dateArray: string[] = []
 
 		for (let i = 0; i <= getDateDiff(period.periodStart, period.periodEnd); i++) {
 			const date = new Date(startDate)
 			date.setDate(startDate.getDate() + i)
 
-			dateArray.push({
-				month: (date.getMonth() + 1).toString(),
-				day: date.getDate().toString(),
-				week: ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'][date.getDay()],
-			})
+			dateArray.push(getFormattedDate(date))
 			/* meetingDates[
 				{month: '1', day: '15', week: '수요일'},
 				...
@@ -55,17 +49,18 @@ const MeetingDateSelector = ({ onSelect, period }: props): JSX.Element => {
 		setMeetingDates(dateArray)
 	}, [period])
 
+	
+
 	// 날짜 클릭 핸들러 (상태값 반환용)
-	const handleDateClick = (date: dateInfo) => {
-		const formattedDate = `${date.month}.${date.day} ${date.week}`
-		setSelectedDate(formattedDate)
-		onSelect(formattedDate)
+	const handleDateClick = (date: string) => {
+		setSelectedDate(date)
+		onSelect(date)
 	}
 
 	return (
 		<div className='flex gap-x-5'>
 			{meetingDates.map((date, index) => (
-				<MeetingDate key={index} {...date} onClick={() => handleDateClick(date)} isSelected={selectedDate === `${date.month}.${date.day} ${date.week}`} />
+				<MeetingDate key={index} onClick={() => handleDateClick(date)} isSelected={selectedDate === date} date={date} />
 			))}
 		</div>
 	)

--- a/src/components/UI/MeetingDateSelector.tsx
+++ b/src/components/UI/MeetingDateSelector.tsx
@@ -41,7 +41,7 @@ const MeetingDateSelector = ({ onSelect, period }: props): JSX.Element => {
 
 			dateArray.push(getFormattedDate(date))
 			/* meetingDates[
-				{month: '1', day: '15', week: '수요일'},
+				{date: '2025-03-12'},
 				...
 			]
 			*/

--- a/src/components/UI/MeetingTime.tsx
+++ b/src/components/UI/MeetingTime.tsx
@@ -1,17 +1,21 @@
 import React, { JSX } from 'react'
 
 interface props {
-	time: string 
+	time: string
 	onClick?: () => void // 시간 선택 핸들러
-	isSelected?: boolean 
+	isSelected?: boolean
+	disabled: boolean
 }
 
-// 면접 시간 선택 버튼 컴포넌트 
-const MeetingTime = ({ time, onClick, isSelected }: props): JSX.Element => {
+// 면접 시간 선택 버튼 컴포넌트
+const MeetingTime = ({ time, onClick, isSelected, disabled }: props): JSX.Element => {
 	return (
 		<button
-			className={`font-pretendardBold text-white rounded-3xl text-center border-2 border-mainColor w-[80px] h-[40px] ${isSelected ? 'bg-mainColor' : 'bg-none'}`}
-			onClick={onClick}>
+			className={`font-pretendardBold text-white rounded-3xl text-center border-2 border-mainColor w-[80px] h-[40px] ${isSelected ? 'bg-mainColor' : 'bg-none'} ${
+				disabled ? 'opacity-30 border-subGrey2 text-subGrey' : 'transition-all hover:bg-[#00937A] active:scale-95'
+			}`}
+			onClick={onClick}
+			disabled={disabled}>
 			{time}
 		</button>
 	)

--- a/src/components/UI/MeetingTimeSelector.tsx
+++ b/src/components/UI/MeetingTimeSelector.tsx
@@ -2,7 +2,6 @@ import React, { JSX, useEffect, useState } from 'react'
 import MeetingTime from './MeetingTime'
 
 interface timeInfo {
-	id: number
 	time: string
 }
 
@@ -12,13 +11,12 @@ interface interviewTime {
 }
 
 interface props {
-	onSelect: (selectedTime: {id: number, time: string}) => void
+	onSelect: (time: string) => void
 	time: interviewTime // 면접 시간 
 	disabledSelectTime: boolean
-	scheduleId: number[]
 }
 
-const MeetingTimeSelector = ({ onSelect, time, disabledSelectTime, scheduleId }: props): JSX.Element => {
+const MeetingTimeSelector = ({ onSelect, time, disabledSelectTime }: props): JSX.Element => {
 	const [selectedTime, setSelectedTime] = useState<string>('')
 	const [meetingTimes, setMeetingTimes] = useState<timeInfo[]>([])
 
@@ -39,29 +37,26 @@ const MeetingTimeSelector = ({ onSelect, time, disabledSelectTime, scheduleId }:
 		const startMinutes = parseTime(time.timeStart)
 		const endMinutes = parseTime(time.timeEnd)
 		const timeArray: timeInfo[] = []
-		let idIndex = 0
 
 		// 20분 간격으로 time 추가, 각 시간별로 고유 ID 부여
 		for (let minutes = startMinutes; minutes <= endMinutes; minutes += 20) {
-			const id = scheduleId[idIndex]
-			timeArray.push({id: id, time:formatTime(minutes)})
-			idIndex++
+			timeArray.push({ time: formatTime(minutes) })
 			/*
 			meetingTimes[
-				{id: 1, time: '12:00'},
-				{id: 2, time: '12:20'},
+				{time: '12:00'},
+				{time: '12:20'},
 				...
 			]
 			*/
 		}
 
 		setMeetingTimes(timeArray)
-	},[time, scheduleId])
+	},[time])
 
 	// 시간 클릭 핸들러 (부모컴포넌트에 state값 반환)
 	const handleTimeClick = (meetingTime: timeInfo) => {
 		setSelectedTime(meetingTime.time)
-		onSelect({id: meetingTime.id, time: meetingTime.time})
+		onSelect(meetingTime.time)
 	}
 	useEffect(() => {
 		console.log('meetingTimes:', meetingTimes) // 여기서 meetingTimes 배열이 제대로 설정되었는지 확인
@@ -69,8 +64,8 @@ const MeetingTimeSelector = ({ onSelect, time, disabledSelectTime, scheduleId }:
 
 	return (	
 		<div className='grid grid-cols-4 gap-x-2 gap-y-5'>
-			{meetingTimes.map((meetingTime) => (
-				<MeetingTime {...meetingTime} onClick={() => handleTimeClick(meetingTime)} isSelected={selectedTime === `${meetingTime.time}`} disabled={disabledSelectTime} />
+			{meetingTimes.map((meetingTime, index ) => (
+				<MeetingTime key={index} {...meetingTime} onClick={() => handleTimeClick(meetingTime)} isSelected={selectedTime === `${meetingTime.time}`} disabled={disabledSelectTime} />
 			))}
 		</div>
 	)

--- a/src/components/UI/MeetingTimeSelector.tsx
+++ b/src/components/UI/MeetingTimeSelector.tsx
@@ -18,6 +18,7 @@ interface props {
 const MeetingTimeSelector = ({ onSelect, time }: props): JSX.Element => {
 	const [selectedTime, setSelectedTime] = useState<string>('')
 	const [meetingTimes, setMeetingTimes] = useState<timeInfo[]>([])
+	const [meetingAble, setMeeintgAble] = useState<boolean>(true)
 
 	// 면접 예약 시간 목록 가져오기
 	useEffect(()=> {
@@ -59,10 +60,10 @@ const MeetingTimeSelector = ({ onSelect, time }: props): JSX.Element => {
 		onSelect(formattedTime)
 	}
 
-	return (
+	return (	
 		<div className='grid grid-cols-4 gap-x-2 gap-y-5'>
 			{meetingTimes.map((meetingTime, index) => (
-				<MeetingTime key={index} {...meetingTime} onClick={() => handleTimeClick(meetingTime)} isSelected={selectedTime === `${meetingTime.time}`} />
+				<MeetingTime key={index} {...meetingTime} onClick={() => handleTimeClick(meetingTime)} isSelected={selectedTime === `${meetingTime.time}`} disabled={meetingAble} />
 			))}
 		</div>
 	)

--- a/src/components/UI/MeetingTimeSelector.tsx
+++ b/src/components/UI/MeetingTimeSelector.tsx
@@ -58,9 +58,6 @@ const MeetingTimeSelector = ({ onSelect, time, disabledSelectTime }: props): JSX
 		setSelectedTime(meetingTime.time)
 		onSelect(meetingTime.time)
 	}
-	useEffect(() => {
-		console.log('meetingTimes:', meetingTimes) // 여기서 meetingTimes 배열이 제대로 설정되었는지 확인
-	}, [meetingTimes])
 
 	return (	
 		<div className='grid grid-cols-4 gap-x-2 gap-y-5'>

--- a/src/components/UI/MeetingTimeSelector.tsx
+++ b/src/components/UI/MeetingTimeSelector.tsx
@@ -2,6 +2,7 @@ import React, { JSX, useEffect, useState } from 'react'
 import MeetingTime from './MeetingTime'
 
 interface timeInfo {
+	id: number
 	time: string
 }
 
@@ -11,14 +12,15 @@ interface interviewTime {
 }
 
 interface props {
-	onSelect: (time: string) => void
+	onSelect: (selectedTime: {id: number, time: string}) => void
 	time: interviewTime // 면접 시간 
+	disabledSelectTime: boolean
+	scheduleId: number[]
 }
 
-const MeetingTimeSelector = ({ onSelect, time }: props): JSX.Element => {
+const MeetingTimeSelector = ({ onSelect, time, disabledSelectTime, scheduleId }: props): JSX.Element => {
 	const [selectedTime, setSelectedTime] = useState<string>('')
 	const [meetingTimes, setMeetingTimes] = useState<timeInfo[]>([])
-	const [meetingAble, setMeeintgAble] = useState<boolean>(true)
 
 	// 면접 예약 시간 목록 가져오기
 	useEffect(()=> {
@@ -37,33 +39,38 @@ const MeetingTimeSelector = ({ onSelect, time }: props): JSX.Element => {
 		const startMinutes = parseTime(time.timeStart)
 		const endMinutes = parseTime(time.timeEnd)
 		const timeArray: timeInfo[] = []
+		let idIndex = 0
 
-		// 20분 간격으로 time 추가
+		// 20분 간격으로 time 추가, 각 시간별로 고유 ID 부여
 		for (let minutes = startMinutes; minutes <= endMinutes; minutes += 20) {
-			timeArray.push({time:formatTime(minutes)})
+			const id = scheduleId[idIndex]
+			timeArray.push({id: id, time:formatTime(minutes)})
+			idIndex++
 			/*
 			meetingTimes[
-				{time:'12:00'},
-				{time:'12:20'},
+				{id: 1, time: '12:00'},
+				{id: 2, time: '12:20'},
 				...
 			]
 			*/
 		}
 
 		setMeetingTimes(timeArray)
-	},[time])
+	},[time, scheduleId])
 
 	// 시간 클릭 핸들러 (부모컴포넌트에 state값 반환)
 	const handleTimeClick = (meetingTime: timeInfo) => {
-		const formattedTime = `${meetingTime.time}`
-		setSelectedTime(formattedTime)
-		onSelect(formattedTime)
+		setSelectedTime(meetingTime.time)
+		onSelect({id: meetingTime.id, time: meetingTime.time})
 	}
+	useEffect(() => {
+		console.log('meetingTimes:', meetingTimes) // 여기서 meetingTimes 배열이 제대로 설정되었는지 확인
+	}, [meetingTimes])
 
 	return (	
 		<div className='grid grid-cols-4 gap-x-2 gap-y-5'>
-			{meetingTimes.map((meetingTime, index) => (
-				<MeetingTime key={index} {...meetingTime} onClick={() => handleTimeClick(meetingTime)} isSelected={selectedTime === `${meetingTime.time}`} disabled={meetingAble} />
+			{meetingTimes.map((meetingTime) => (
+				<MeetingTime {...meetingTime} onClick={() => handleTimeClick(meetingTime)} isSelected={selectedTime === `${meetingTime.time}`} disabled={disabledSelectTime} />
 			))}
 		</div>
 	)

--- a/src/pages/RecruitCheck.tsx
+++ b/src/pages/RecruitCheck.tsx
@@ -1,14 +1,21 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import MobileLayout from '../components/layout/MobileLayout'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { RecruitHeader, RecruitUI_SUB, RecruitUI_SUB2 } from '../components/UI/RecruitUI'
 import { Button } from '../components/UI/Recruit_Button'
 
-
 const RecruitCheck: React.FC = () => {
     const navigate = useNavigate()
     const location = useLocation()
-    const {name, isPassed} = location.state as {name:string, isPassed:boolean}
+    const {name, isPassed, studentNo, contactLastDigit} = location.state as {name:string, isPassed:boolean, studentNo:string, contactLastDigit:string}
+
+    // 1차 합격시 개인 코드 생성 후 session에 저장
+    useEffect(()=> {
+        if(isPassed) {
+            const reservationCode = studentNo + contactLastDigit
+            sessionStorage.setItem('reservationCode', reservationCode)
+        }
+    },[])
 
     return (
         <MobileLayout>

--- a/src/pages/RecruitMeeting.tsx
+++ b/src/pages/RecruitMeeting.tsx
@@ -63,7 +63,7 @@ const RecruitMeeting: React.FC = () => {
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
-				const response = await axios.get<recruitData[]>('https://dmu-dasom.or.kr/api/recruit')
+				const response = await axios.get<recruitData[]>('https://dmu-dasom-api.or.kr/api/recruit')
 
 				// KEY값 검색하여 데이터 조회하여 각 변수에 저장
 				const periodData: interviewPeriod = {
@@ -85,6 +85,15 @@ const RecruitMeeting: React.FC = () => {
 		}
 		fetchData()
 	}, [])
+
+	// 음... 서버에서 예약 현황 받아와야함
+	// 페이지 맨 처음 들어와서는 시간 선택 불가능하게
+	// 날짜 선택하면 선택한 날짜에 예약 가능한 시간만 선택 가능하도록
+	// 날짜 선택 값에 따라 시간 버튼 on off 유무 필요함
+	// 예약 현황 데이터가 어떻게 들어오는지 모르겠는데... 데이터 형식 바꿔서 읽어야 될수도...
+	// 합격 조회시 학번 + 전화번호뒷자리 로 개인코드 생성
+	// 면접 예약 페이지 접근 시 코드 없으면 접근 불가
+	// 면접 예약시 이 코드도 함께 api에 전달
 
 	return (
 		<MobileLayout>

--- a/src/pages/RecruitMeeting.tsx
+++ b/src/pages/RecruitMeeting.tsx
@@ -42,7 +42,7 @@ const RecruitMeeting: React.FC = () => {
 	const [interviewSlots, setInterviewSlots] = useState<any[]>([])
 	const [slotId, setSlotId] = useState<number>()
 
-	// 날짜 선택 핸들러
+	// 날짜 선택 핸들러, 날짜 선택 후 시간 선택 가능
 	const handleDateSelect = (date: string) => {
 		setSelectedDate(date)
 
@@ -97,7 +97,7 @@ const RecruitMeeting: React.FC = () => {
 		selectedDate && selectedTime ? setActivebtn(true) : setActivebtn(false)
 	}, [selectedDate, selectedTime])
 
-	// 면접 일정 조회
+	// 일정 조회
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
@@ -124,6 +124,7 @@ const RecruitMeeting: React.FC = () => {
 		fetchData()
 	}, [])
 
+	// 생성된 면접 예약 일정 조회회
 	useEffect(() => {
 		const searchSchedule = async () => {
 			try {
@@ -145,12 +146,6 @@ const RecruitMeeting: React.FC = () => {
 			setSlotId(matchedSlots[0].id)
 		}
 	}, [selectedDate, selectedTime])
-
-	useEffect(() => {
-		console.log('선택한 날짜 ->', selectedDate)
-		console.log('선택한 시간 ->', selectedTime)
-		console.log('슬롯 id 체크 -> ', slotId)
-	}, [selectedDate, selectedTime, slotId])
 	
 	return (
 		<MobileLayout>

--- a/src/pages/RecruitMeeting.tsx
+++ b/src/pages/RecruitMeeting.tsx
@@ -56,8 +56,8 @@ const RecruitMeeting: React.FC = () => {
 	const handleSubmit = async () => {
 		try {
 			await axios.post('https://dmu-dasom-api.or.kr/api/recruit/interview/reserve', {
-				slotId: selectedTime.id,
-				reservationCode: reservationCode,
+				slotId: selectedTime.id,	// 면접 예약할 슬롯 ID
+				reservationCode: reservationCode,	// 예약코드
 			})
 			// 선택된 날짜와 시간 state값 전달하여 페이지 이동
 			navigate('/recruit/meeting/submit', { state: { date: selectedDate, time: selectedTime } })
@@ -139,7 +139,7 @@ const RecruitMeeting: React.FC = () => {
 					endTime: interviewTimeData.timeEnd
 				})
 				// 응답에서 id 값을 추출
-				const createdSchedules = response.data  // 예시: [{ id: 865, interviewDate: "2025-03-12", ... }]
+				const createdSchedules = response.data 
             
 				// id를 배열로 추출
 				const ids = createdSchedules.map((schedule: { id: number }) => schedule.id)
@@ -150,7 +150,7 @@ const RecruitMeeting: React.FC = () => {
 				alert('면접 일정 생성 중 오류가 발생했습니다.')
 			}
 		}
-		createSchedule()
+		//createSchedule()
 	}, [interviewPeriodData, interviewTimeData])
 	
 	return (

--- a/src/pages/RecruitResult.tsx
+++ b/src/pages/RecruitResult.tsx
@@ -56,7 +56,6 @@ export const RecruitResult: React.FC = () => {
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault()
 
-
 		if (!checkInput.studentNo.trim()) {
 			alert('학번을 입력해주세요.')
 			return
@@ -86,11 +85,13 @@ export const RecruitResult: React.FC = () => {
 				isPassed: response.data.isPassed,
 			}
 
-			// 조회 type에 따라 이동 url 다르게 
+			// 조회 type에 따라 이동 url 다르게
 			navigate(`/recruit/${pass === 'DOCUMENT_PASS' ? 'check' : 'check/final'}`, {
 				state: {
 					name: resData.name,
 					isPassed: resData.isPassed,
+					studentNo: checkInput.studentNo,
+					contactLastDigit: checkInput.contact
 				},
 			})
 		} catch (e) {
@@ -109,13 +110,9 @@ export const RecruitResult: React.FC = () => {
 			const elements = Array.from(form.elements) as (HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)[]
 			const index = elements.indexOf(e.currentTarget)
 
-
 			for (let i = index + 1; i < elements.length; i++) {
 				const nextElement = elements[i]
-				if (
-					(nextElement instanceof HTMLInputElement || nextElement instanceof HTMLTextAreaElement) &&
-					nextElement.readOnly
-				) {
+				if ((nextElement instanceof HTMLInputElement || nextElement instanceof HTMLTextAreaElement) && nextElement.readOnly) {
 					continue
 				}
 
@@ -140,7 +137,15 @@ export const RecruitResult: React.FC = () => {
 					onChange={handleInputChange}
 					onKeyDown={handleKeyPress}
 				/>
-				<InputField label='전화번호 마지막 4자리를 입력해주세요.' subLabel='ex) 0542' type='text' name='contact' value={checkInput.contact} onChange={handleInputChange} onKeyDown={handleKeyPress} />
+				<InputField
+					label='전화번호 마지막 4자리를 입력해주세요.'
+					subLabel='ex) 0542'
+					type='text'
+					name='contact'
+					value={checkInput.contact}
+					onChange={handleInputChange}
+					onKeyDown={handleKeyPress}
+				/>
 				<Button text='결과 확인하기' />
 			</form>
 		</MobileLayout>

--- a/src/pages/RecruitSubmitMeeting.tsx
+++ b/src/pages/RecruitSubmitMeeting.tsx
@@ -4,6 +4,14 @@ import MobileLayout from '../components/layout/MobileLayout'
 import { RecruitHeader, RecruitUI } from '../components/UI/RecruitUI'
 import { Recruit_InfoBanner } from '../components/UI/Recruit_InfoBanner'
 
+const getDisplatyDate = (date:string) => {
+	const d = new Date(date)
+	const month = (d.getMonth() + 1).toString()
+	const day = d.getDate().toString()
+	const week = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'][d.getDay()]
+    return `${month}.${day} ${week}`
+}
+
 const RecruitSubmitMeeting: React.FC = () => {
 	const location = useLocation()
 	const { date, time } = location.state as { date: string; time: string }
@@ -14,7 +22,7 @@ const RecruitSubmitMeeting: React.FC = () => {
 			<RecruitUI />
 			<Recruit_InfoBanner 
 			message={`면접일 제출이 완료되었습니다. 
-			${date} ${time} 에 만나뵙겠습니다. 감사합니다.`} />
+			${getDisplatyDate(date)} ${time} 에 만나뵙겠습니다. 감사합니다.`} />
 		</MobileLayout>
 	)
 }

--- a/src/pages/admin/ManRecruitDate.tsx
+++ b/src/pages/admin/ManRecruitDate.tsx
@@ -80,6 +80,22 @@ const ManRecruitDate = () => {
         }
     }
 
+    const handleCreateSchedule = async () => {
+        try {
+            const response = await axios.post('https://dmu-dasom-api.or.kr/api/recruit/interview/schedule', {
+                startDate: dates.INTERVIEW_PERIOD_START.format('YYYY-MM-DD'),
+                endDate: dates.INTERVIEW_PERIOD_END.format('YYYY-MM-DD'),
+                startTime: dates.INTERVIEW_TIME_START.format('HH:mm'),
+                endTime: dates.INTERVIEW_TIME_END.format('HH:mm')
+            })
+
+            console.log('생성된 면접 일정 : ', response.data)
+        } catch (e: any) {
+            console.log(e)
+            alert('면접 일정 생성 중 오류가 발생했습니다.')
+        }
+    }
+
     // 일정 저장
     const handleSave = async (key: keyof typeof dates) => {
         const formattedData = {
@@ -146,6 +162,7 @@ const ManRecruitDate = () => {
                     </div>
                 </div>
             </LocalizationProvider>
+            <button className='w-[140px] h-[40px] bg-mainColor mt-[15px] font-pretendardBold' onClick={handleCreateSchedule}>면접 일정 생성하기</button>
         </div>
     )
 }


### PR DESCRIPTION
# [feat] 면접 예약 페이지 API 연동 - 2

## Issue
- #66

## 변경 내용
- RecruitMeeting 페이지 api 주소 변경
- 어드민 일정 관리 페이지 면접 일정 생성 버튼 추가
- 예약코드 설정 추가
- 버튼 애니메이션 추가
- 면접 날짜 데이터 선언 형식 변경
- 면접 예약 api 추가

## 구현 내용
- 일정관리 페이지 면접 일정 생성 버튼 recruit 페이지 버튼 디자인 참고해서 임의로 생성해놨습니다
- 1차합격 조회시에만 예약코드 생성되도록 설정했습니다
- 날짜 선택 후에 시간 선택 가능하게 하였습니다
- 날짜 선택 및 시간 선택 값으로 slotId 조회하도록 설정했습니다