### PR TITLE
[feat] 어드민 면접자 조회 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import ManNewsDetail from './pages/admin/ManNewsDetail'
 import ManNewsPost from './pages/admin/ManNewsPost'
 import ManNewsEdit from './pages/admin/ManNewsEdit'
 import ManRecruitDate from './pages/admin/ManRecruitDate'
+import ManInterviewee from './pages/admin/ManInterviewee'
 import UserMain from './pages/UserMain'
 import Recruit from './pages/Recruit'
 import CoreMembers from './pages/CoreMembers'
@@ -62,6 +63,7 @@ function AppContent() {
 				{/* 관리자 페이지 */}
 				<Route path='/admin' element={<ProtectedRoute><AdminMain /></ProtectedRoute>} />
 				<Route path='/admin/applicants' element={<ProtectedRoute><ManApplicants /></ProtectedRoute>} />
+				<Route path='/admin/applicants/interviewee' element={<ProtectedRoute><ManInterviewee /></ProtectedRoute>} />
 				<Route path='/admin/date' element={<ProtectedRoute><ManRecruitDate /></ProtectedRoute>} />
         		<Route path='/admin/news' element={<ProtectedRoute><ManNewsList /></ProtectedRoute>} />
 				<Route path='/admin/news/:no' element={<ProtectedRoute><ManNewsDetail /></ProtectedRoute>} />

--- a/src/components/UI/AdminPagination.tsx
+++ b/src/components/UI/AdminPagination.tsx
@@ -8,7 +8,7 @@ interface PaginationProps {
 
 const AdminPagination: React.FC<PaginationProps> = ({ currentPage, totalPages, setCurrentPage }) => {
     return (
-        <div className='mt-6 space-x-4'>
+        <div className='my-6 space-x-4'>
             <button 
                 className='px-4 py-2 bg-gray-700 text-white rounded-lg disabled:opacity-50' 
                 onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))} 

--- a/src/pages/Recruit.tsx
+++ b/src/pages/Recruit.tsx
@@ -125,7 +125,7 @@ const Recruit: React.FC = () => {
       })
 
       if (response.ok) {
-        navigate('/recruit-submit')
+        navigate('/recruit/submit')
       } else {
         const errorData = await response.json()
       }

--- a/src/pages/admin/ManApplicants.tsx
+++ b/src/pages/admin/ManApplicants.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import axios from 'axios'
 import { toast, ToastContainer } from 'react-toastify'
+import { useNavigate } from 'react-router-dom'
 import 'react-toastify/dist/ReactToastify.css'
 import AdminPagination from '../../components/UI/AdminPagination'
 
@@ -9,6 +10,7 @@ const ManApplicants: React.FC = () => {
     const [count, setCount] = useState<number>(0)                       // 지원자 수
     const [detailInfo, setDetailInfo] = useState<any>(null)             // 특정 지원자 상세정보
     const [selectedId, setSelectedId] = useState<number | null>(null)   // 상태 변경 시 선택된 지원자id
+    const navigate = useNavigate()
 
     const accessToken = localStorage.getItem('accessToken')
     
@@ -190,10 +192,16 @@ const ManApplicants: React.FC = () => {
     
 
     return (
-        <div className='h-[100vh] w-[100vw] bg-mainBlack font-pretendardRegular text-white flex flex-col items-center'>
+        <div className='h-[100vh] w-[100vw] bg-mainBlack font-pretendardRegular text-white flex flex-col items-center overflow-y-auto'>
             <ToastContainer />
-            <div className='mb-[4px] mt-[155px] justify-start w-[1220px]'>
-                <span className='font-pretendardBold text-mainColor'>{count}</span>명의 지원자가 있습니다.
+            <div className='mb-[4px] mt-[155px] flex justify-between w-[1220px]'>
+                <div><span className='font-pretendardBold text-mainColor'>{count}</span>명의 지원자가 있습니다.</div>
+                <div 
+                    className='cursor-pointer px-2 py-1 bg-gray-700 text-white rounded-lg'
+                    onClick={() => {navigate('/admin/applicants/interviewee')}}
+                >
+                    면접자 조회
+                </div>
             </div>
 
             {/* 지원자 목록 테이블 */}
@@ -207,7 +215,7 @@ const ManApplicants: React.FC = () => {
                         <th className='border border-gray-500 py-[4px]'>상세정보</th>
                     </tr>
                 </thead>
-                <tbody className='overflow-y-auto max-h-[calc(100vh)]'>
+                <tbody>
                     {currentApplicants.map((applicant) => (
                         <ApplicantInfo key={applicant.id} applicant={applicant} />
                     ))}

--- a/src/pages/admin/ManInterviewee.tsx
+++ b/src/pages/admin/ManInterviewee.tsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useState } from 'react'
+import AdminPagination from '../../components/UI/AdminPagination'
+import axios from 'axios'
+
+interface Applicant {
+    applicantId: number
+    applicantName: string
+    studentNo: string
+    contact: string
+    email: string
+    activityWish: string
+    reasonForApply: string
+    interviewDate: string
+    interviewTime: string
+    appliedDate: string
+}
+
+interface CustomTooltipProps {
+    text: string
+    children: React.ReactNode
+}
+
+const Table: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <div className='mb-[4px] flex justify-between w-[1220px]'>
+        <table className='w-[1220px] border border-gray-500 text-white'>{children}</table>
+    </div>
+)
+
+const CustomTooltip: React.FC<CustomTooltipProps> = ({ text, children }) => {
+    const [showFullText, setShowFullText] = useState(false)
+  
+    const handleClick = () => {
+      setShowFullText(!showFullText)
+    }
+  
+    return (
+        <div className="relative inline-block">
+            {children}
+            {/* 더보기 버튼 */}
+            <button
+                onClick={handleClick}
+                className="ml-2 text-gray-400 text-sm"
+            >
+                {showFullText ? '닫기' : '더보기'}
+            </button>
+            {/* 더보기 클릭 시 표시되는 텍스트 */}
+            {showFullText && (
+                <div className="absolute left-1/2 transform -translate-x-1/2 top-full mt-2 w-max max-w-[400px] bg-black text-white text-[16px] rounded p-2 z-30">
+                    {text}
+                </div>
+            )}
+        </div>
+    )
+}
+
+const ManInterviewee: React.FC = () => {
+    const [applicants, setApplicants] = useState<Applicant[]>([])
+    const [searchTerm, setSearchTerm] = useState<string>('')
+    const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
+    const [sortBy, setSortBy] = useState<'interview' | 'applied'>('interview')
+
+    useEffect(() => {
+        const fetchApplicants = async () => {
+        try {
+            const response = await axios.get<Applicant[]>('https://dmu-dasom-api.or.kr/api/recruit/interview/applicants')
+            setApplicants(response.data)
+        } catch (error) {
+            console.error('면접 예약자 데이터를 불러오는 중 오류 발생:', error)
+        }
+        }
+        fetchApplicants()
+    }, [])
+
+    const truncateText = (text: string, length: number) => {
+        return text.length > length ? text.slice(0, length) + '...' : text
+    }
+
+    const filteredApplicants = applicants.filter((applicant) =>
+        applicant.applicantName.toLowerCase().includes(searchTerm.toLowerCase())
+    )
+
+    // 면접 일시 및 면접 신청 일시 sort
+    const handleSort = (sortType: 'interview' | 'applied') => {
+        setSortBy(sortType)
+        const sortedApplicants = [...filteredApplicants].sort((a, b) => {
+        let aDate, bDate
+
+        if (sortType === 'interview') {
+            aDate = new Date(`${a.interviewDate} ${a.interviewTime}`)
+            bDate = new Date(`${b.interviewDate} ${b.interviewTime}`)
+        } else {
+            aDate = new Date(a.appliedDate)
+            bDate = new Date(b.appliedDate)
+        }
+
+        if (sortOrder === 'asc') {
+            return aDate.getTime() - bDate.getTime()
+        } else {
+            return bDate.getTime() - aDate.getTime()
+        }
+        })
+
+        setApplicants(sortedApplicants)
+        setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')
+    }
+
+    // 페이지네이션
+    const [currentPage, setCurrentPage] = useState<number>(1)
+    const [itemsPerPage] = useState<number>(20)
+    const indexOfLastApplicant = currentPage * itemsPerPage
+    const indexOfFirstApplicant = indexOfLastApplicant - itemsPerPage
+    const currentApplicants = filteredApplicants.slice(indexOfFirstApplicant, indexOfLastApplicant)
+    const totalPages = Math.ceil(filteredApplicants.length / itemsPerPage)
+
+    return (
+        <div className='h-[100vh] w-[100vw] bg-mainBlack font-pretendardRegular text-white flex flex-col items-center overflow-y-auto'>
+        <div className='flex justify-between w-[1220px] mt-[155px] mb-[4px]'>
+            <div className='text-[20px] font-pretendardRegular'>면접 예약자 조회</div>
+            <input
+                type='text'
+                placeholder='이름으로 검색'
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className='text-black px-2 py-1 border border-gray-300 rounded'
+            />
+        </div>
+        <Table>
+            <thead>
+            <tr className='border border-gray-500 py-[4px] font-pretendardBold'>
+                <th className='py-[4px] border border-gray-500 w-[120px]'>이름</th>
+                <th className='py-[4px] border border-gray-500 w-[150px]'>학번</th>
+                <th className='py-[4px] border border-gray-500 w-[150px]'>연락처</th>
+                <th className='py-[4px] border border-gray-500 w-[250px]'>지원 동기</th>
+                <th className='py-[4px] border border-gray-500'>활동 희망 사항</th>
+                <th
+                    className='py-[4px] border border-gray-500 w-[150px] cursor-pointer'
+                    onClick={() => handleSort('interview')}
+                >
+                    면접 일시 {sortBy === 'interview' && (sortOrder === 'asc' ? '↑' : '↓')}
+                </th>
+                <th
+                    className='py-[4px] border border-gray-500 w-[150px] cursor-pointer'
+                    onClick={() => handleSort('applied')}
+                >
+                    면접 신청 일시 {sortBy === 'applied' && (sortOrder === 'asc' ? '↑' : '↓')}
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            {currentApplicants.map((applicant) => (
+                <tr key={applicant.applicantId} className='py-[4px]'>
+                <td className='border border-gray-500 p-1 text-center'>{applicant.applicantName}</td>
+                <td className='border border-gray-500 p-1 text-center'>{applicant.studentNo}</td>
+                <td className='border border-gray-500 p-1 text-center'>{applicant.contact}</td>
+                <td className='border border-gray-500 p-1'>
+                    <CustomTooltip text={applicant.reasonForApply}>
+                    <span>{truncateText(applicant.reasonForApply, 20)}</span>
+                    </CustomTooltip>
+                </td>
+                <td className='border border-gray-500 p-1'>
+                    <CustomTooltip text={applicant.activityWish}>
+                    <span>{truncateText(applicant.activityWish, 20)}</span>
+                    </CustomTooltip>
+                </td>
+                <td className='border border-gray-500 p-1 text-center'>
+                    {`${applicant.interviewDate} ${applicant.interviewTime}`}
+                </td>
+                <td className='border border-gray-500 p-1 text-center'>
+                    {new Date(applicant.appliedDate).toLocaleDateString('ko-KR')} {new Date(applicant.appliedDate).toLocaleTimeString('en-GB', { hour12: false })}
+                </td>
+                </tr>
+            ))}
+            </tbody>
+        </Table>
+        <AdminPagination 
+            currentPage={currentPage} 
+            totalPages={totalPages} 
+            setCurrentPage={setCurrentPage} 
+        />
+        </div>
+    )
+}
+
+export default ManInterviewee


### PR DESCRIPTION
# [feat] 어드민 면접자 조회 페이지 구현

## Issue
- #104 

## 변경 내용
- 어드민 면접자 조회 페이지 구현 완료

## 구현 사항
- 면접자 조회 페이지 UI 및 api 연동 완료했습니다
- 어드민메인-> 지원자 관리 -> 면접자 조회 루트로 들어가도록 구성했습니다
- 지원자가 늘어날 경우 지원자 관리 페이지에서도 스크롤이 제대로 안생겨서 같이 수정했습니다