### PR TITLE
[fix] 지원자 관리 이메일 버튼 및 학년 정보 추가

### DIFF
--- a/src/components/UI/MailButtons.tsx
+++ b/src/components/UI/MailButtons.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import axios from 'axios'
+import { toast } from 'react-toastify'
+
+const sendResultMail = async (mailType : any) => {
+    const confirmation = window.confirm(`${mailType === 'DOCUMENT_RESULT' ? '서류' : '면접접'} 합격자에게 메일을 보낼까요?`)
+    if (!confirmation) return
+    const accessToken = localStorage.getItem('accessToken')
+
+    try {
+        await axios.post('https://dmu-dasom-api.or.kr/api/admin/applicants/send-mail', { mailType }, {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`
+                }
+            })
+        toast.success(`${mailType === 'DOCUMENT_RESULT' ? '서류' : '면접'} 합격자에게 메일을 발송했습니다.`)
+    } catch (error) {
+        toast.error('메일 발송에 실패했습니다.')
+        console.error('메일 발송 오류:', error)
+    }
+}
+
+const MailButtons = () => {
+    return (
+        <div className='mt-[12px]'>
+            <button 
+                className='cursor-pointer px-2 py-1 bg-gray-700 text-white rounded-lg mr-3'
+                onClick={() => sendResultMail('DOCUMENT_RESULT')}
+            >
+                서류 합격자 메일 발송
+            </button>
+            <button 
+                className='cursor-pointer px-2 py-1 bg-gray-700 text-white rounded-lg'
+                onClick={() => sendResultMail('FINAL_RESULT')}
+            >
+                면접 합격자 메일 발송
+            </button>
+        </div>
+    )
+}
+
+export default MailButtons

--- a/src/pages/admin/ManApplicants.tsx
+++ b/src/pages/admin/ManApplicants.tsx
@@ -4,6 +4,7 @@ import { toast, ToastContainer } from 'react-toastify'
 import { useNavigate } from 'react-router-dom'
 import 'react-toastify/dist/ReactToastify.css'
 import AdminPagination from '../../components/UI/AdminPagination'
+import MailButtons from '../../components/UI/MailButtons'
 
 const ManApplicants: React.FC = () => {
     const [applicants, setApplicants] = useState<any[]>([])             // 전체 조회 시 지원자 정보
@@ -222,6 +223,9 @@ const ManApplicants: React.FC = () => {
                     ))}
                 </tbody>
             </table>
+            <div className='w-[1220px]'>
+                <MailButtons />
+            </div>
             {/* 페이지네이션 */}
             <AdminPagination 
                 currentPage={currentPage} 


### PR DESCRIPTION
# [fix] 지원자 관리 이메일 버튼 및 학년 정보 추가

## 변경내용
- 지원자 조회 상세보기 중 학년 정보 추가
- 이메일 전송 버튼 추가

## 구현사항
- MailButtons 컴퍼넌트 추가해서 지원자 관리 페이지 하단에 이메일 전송 버튼 추가해놨습니다