### PR TITLE
[feat] 면접 예약 페이지 시간 선택 비활성화 추가

### DIFF
--- a/src/components/UI/MeetingTimeSelector.tsx
+++ b/src/components/UI/MeetingTimeSelector.tsx
@@ -12,34 +12,35 @@ interface interviewTime {
 
 interface props {
 	onSelect: (time: string) => void
-	time: interviewTime // 면접 시간 
+	time: interviewTime // 면접 시간
 	disabledSelectTime: boolean
+	slotsForDate: any[]
 }
 
-const MeetingTimeSelector = ({ onSelect, time, disabledSelectTime }: props): JSX.Element => {
+const MeetingTimeSelector = ({ onSelect, time, disabledSelectTime, slotsForDate }: props): JSX.Element => {
 	const [selectedTime, setSelectedTime] = useState<string>('')
 	const [meetingTimes, setMeetingTimes] = useState<timeInfo[]>([])
 
 	// 면접 예약 시간 목록 가져오기
-	useEffect(()=> {
-		//time -> 분으로 변환 
-		const parseTime = (timeStr:string):number => {
+	useEffect(() => {
+		//time -> 분으로 변환
+		const parseTime = (timeStr: string): number => {
 			const [hours, minutes] = timeStr.split(':').map(Number)
 			return hours * 60 + minutes
 		}
-		// 분(totalMinutes)을 08:00 형식으로 변환 
-		const formatTime = (totalMinutes:number):string => {
-			const hours = Math.floor(totalMinutes/60)
+		// 분(totalMinutes)을 08:00 형식으로 변환
+		const formatTime = (totalMinutes: number): string => {
+			const hours = Math.floor(totalMinutes / 60)
 			const minutes = totalMinutes % 60
-			return `${String(hours).padStart(2,'0')}:${String(minutes).padStart(2,'0')}`
+			return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`
 		}
 
 		const startMinutes = parseTime(time.timeStart)
 		const endMinutes = parseTime(time.timeEnd)
 		const timeArray: timeInfo[] = []
 
-		// 20분 간격으로 time 추가, 각 시간별로 고유 ID 부여
-		for (let minutes = startMinutes; minutes <= endMinutes; minutes += 20) {
+		// endMinutes 이전까지 20분 간격으로 time 추가
+		for (let minutes = startMinutes; minutes < endMinutes; minutes += 20) {
 			timeArray.push({ time: formatTime(minutes) })
 			/*
 			meetingTimes[
@@ -51,7 +52,7 @@ const MeetingTimeSelector = ({ onSelect, time, disabledSelectTime }: props): JSX
 		}
 
 		setMeetingTimes(timeArray)
-	},[time])
+	}, [time])
 
 	// 시간 클릭 핸들러 (부모컴포넌트에 state값 반환)
 	const handleTimeClick = (meetingTime: timeInfo) => {
@@ -59,11 +60,22 @@ const MeetingTimeSelector = ({ onSelect, time, disabledSelectTime }: props): JSX
 		onSelect(meetingTime.time)
 	}
 
-	return (	
+	return (
 		<div className='grid grid-cols-4 gap-x-2 gap-y-5'>
-			{meetingTimes.map((meetingTime, index ) => (
-				<MeetingTime key={index} {...meetingTime} onClick={() => handleTimeClick(meetingTime)} isSelected={selectedTime === `${meetingTime.time}`} disabled={disabledSelectTime} />
-			))}
+			{meetingTimes.map((meetingTime, index) => {
+				const matchingSlot = slotsForDate.find(slot => slot.startTime.startsWith(meetingTime.time))
+				const isActive = matchingSlot?.interviewStatus === 'ACTIVE'
+
+				return (
+					<MeetingTime
+						key={index}
+						{...meetingTime}
+						onClick={() => handleTimeClick(meetingTime)}
+						isSelected={selectedTime === `${meetingTime.time}`}
+						disabled={!isActive || disabledSelectTime}
+					/>
+				)
+			})}
 		</div>
 	)
 }

--- a/src/components/UI/Recruit_Button.tsx
+++ b/src/components/UI/Recruit_Button.tsx
@@ -12,7 +12,7 @@ export const Button: React.FC<ButtonProps> = ({ text, className, onClick, disabl
   return (
     <div className='w-full max-w-[395px] mt-20 mb-20 flex justify-center '>
       <button type="submit"
-        className={`bg-[#00B493] max-w-[395px] h-[30px]  text-white font-pretendardBold px-4 text-[12px] transition-all hover:bg-[#00937A] active:scale-95 ${className}`}
+        className={`bg-[#00B493] max-w-[395px] h-[30px]  text-white font-pretendardBold px-4 text-[12px] transition-all ${!disabled ? 'hover:bg-[#00937A] active:scale-95' : null }  ${className}`}
         onClick={onClick}  
         disabled={disabled}  
       >

--- a/src/pages/RecruitMeeting.tsx
+++ b/src/pages/RecruitMeeting.tsx
@@ -41,16 +41,14 @@ const RecruitMeeting: React.FC = () => {
 	const [disableSelectTime, setDisableSelectTime] = useState<boolean>(true)
 	const [interviewSlots, setInterviewSlots] = useState<any[]>([])
 	const [slotId, setSlotId] = useState<number>()
+	const [slotsForDate, setSlotsForDate] = useState<any[]>([])
 
 	// 날짜 선택 핸들러, 날짜 선택 후 시간 선택 가능
 	const handleDateSelect = (date: string) => {
 		setSelectedDate(date)
-
-		const slotsForDate = interviewSlots.filter((slot) => slot.interviewDate === date)
-
-		const hasActiveSlots = slotsForDate.some((slot) => slot.interviewStatus === 'ACTIVE')
-
-		setDisableSelectTime(!hasActiveSlots)
+		// 선택한 날짜의 time슬롯 저장
+		setSlotsForDate(interviewSlots.filter((slot) => slot.interviewDate === date))
+		setDisableSelectTime(false)
 	}
 
 	// 시간 선택 핸들러
@@ -124,23 +122,21 @@ const RecruitMeeting: React.FC = () => {
 		fetchData()
 	}, [])
 
-	// 생성된 면접 예약 일정 조회회
+	// 생성된 면접 예약 일정 조회
 	useEffect(() => {
 		const searchSchedule = async () => {
 			try {
 				const response = await axios.get('https://dmu-dasom-api.or.kr/api/recruit/interview/all')
 				setInterviewSlots(response.data)
-				console.log(interviewSlots)
 			} catch (e:any) {
 				console.log(e)
 				alert('면접 일정을 조회할 수 없습니다')
 			}
 		}
 		searchSchedule()
-	},[])
+	},[interviewPeriodData, interviewTimeData])
 
 	useEffect(() => {
-		console.log('인터뷰 슬롯 -> ',interviewSlots)
 		if (selectedDate && selectedTime) {
 			const matchedSlots = interviewSlots.filter((slot) => slot.interviewDate === selectedDate && slot.startTime === `${selectedTime}:00`)
 			setSlotId(matchedSlots[0].id)
@@ -160,7 +156,7 @@ const RecruitMeeting: React.FC = () => {
 					<p className='font-pretendardBold text-white mb-4'>면접일</p>
 					<MeetingDateSelector onSelect={handleDateSelect} period={interviewPeriodData} />
 					<p className='font-pretendardBold text-white mt-14 mb-4'>시간</p>
-					<MeetingTimeSelector onSelect={handleTimeSelect} time={interviewTimeData} disabledSelectTime={disableSelectTime} />
+					<MeetingTimeSelector onSelect={handleTimeSelect} time={interviewTimeData} disabledSelectTime={disableSelectTime} slotsForDate={slotsForDate} />
 				</div>
 
 				<Button className={`text-center p-1   ${activebtn ? 'bg-mainColor' : 'bg-subGrey3 opacity-30'}`} onClick={handleSubmit} disabled={!activebtn} text='면접일정 예약하기' />


### PR DESCRIPTION
# [feat] 면접 예약 페이지 시간 선택 비활성화 추가

## Issue
- #113 

## 변경 내용
- recruit버튼 비활성화시 애니메이션도 같이 비활성화 되도록 변경
- RecruitMeeting페이지 선택한 날짜의 예약 시간 슬롯 데이터를 저장하는 state 추가
- slot의 interviewStatus가 ACITVE가 아닌 시간만 선택 비활성화
