### PR TITLE
[Feat] 솜커톤 인원 관리 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { RecruitSubmit } from './pages/RecruitSubmit'
 import RecruitCheck from './pages/RecruitCheck'
 import RecruitCheckFinal from './pages/RecruitCheckFinal'
 import ProtectedRoute from './components/layout/ProtectRoute'
+import SomkatonApplicants from './pages/admin/SomkatonApplicants'
 
 function App() {
 	return (
@@ -69,6 +70,7 @@ function AppContent() {
 				<Route path='/admin/news/:no' element={<ProtectedRoute><ManNewsDetail /></ProtectedRoute>} />
 				<Route path='/admin/news/post' element={<ProtectedRoute><ManNewsPost /></ProtectedRoute>} />
 				<Route path='/admin/news/edit/:no' element={<ProtectedRoute><ManNewsEdit /></ProtectedRoute>} />
+				<Route path='/admin/somkathon' element={<ProtectedRoute><SomkatonApplicants/></ProtectedRoute>}/>
 			</Routes>
 		</>
 	)

--- a/src/pages/admin/AdminMain.tsx
+++ b/src/pages/admin/AdminMain.tsx
@@ -42,6 +42,7 @@ const AdminMain: React.FC = () => {
                 <AdminMenuBtn text='지원자 관리' link='/admin/applicants' />
                 <AdminMenuBtn text='일정 관리' link='/admin/date' />
                 <AdminMenuBtn text='공지사항 관리' link='/admin/news' />
+                <AdminMenuBtn text='솜커톤 지원자 관리' link='/admin/somkathon' />
                 <div 
                     className='cursor-pointer text-[14px] font-pretendardRegular text-white'
                     onClick={handleLogout}

--- a/src/pages/admin/SomkatonApplicants.tsx
+++ b/src/pages/admin/SomkatonApplicants.tsx
@@ -1,0 +1,132 @@
+import axios from 'axios'
+import React, { useEffect, useState } from 'react'
+
+const SomkatonApplicants: React.FC =() => {
+    const [applicants, setApplicants] = useState<any[]>([])
+    const [detailInfo, setDetailInfo] = useState<any>(null)
+    const [selectedId, setSelectedId] = useState<number | null> (null)
+    const [count, setCount] = useState<number>(0)
+    const accessToken = localStorage.getItem('accessToken')
+
+    // 지원자 전체 조회
+    const getData = async () => {
+      try {
+          if(!accessToken) {
+              alert('로그인이 필요합니다.')
+              return
+          }
+          const response = await axios.get('https://dmu-dasom-api.or.kr/api/somkathon/participants')
+          console.log(response.data)
+          setApplicants(response.data)
+          setCount(response.data.length)
+      } catch (e:any) {
+          alert('지원자 목록 불러오기 실패')
+          console.log(e)
+      }
+  }
+
+    useEffect(() => {
+        getData()
+    },[])
+
+    // 지원자 상세 조회
+    const toggleDetail = async (id:number) => {
+      if(selectedId === id) {
+        setSelectedId(null)
+        setDetailInfo(null)
+        return
+      }
+
+      try {
+        const response = await axios.get(`https://dmu-dasom-api.or.kr/api/somkathon/participants/${id}`)
+        setDetailInfo(response.data)
+        setSelectedId(id)
+      } catch (e:any) {
+        console.log(e)
+        alert('지원자 상세정보 불러오기 실패')
+      }
+    }
+
+    const handleDelete = async (id:number) => {
+      try {
+        await axios.delete(`https://dmu-dasom-api.or.kr/api/somkathon/participants/${id}`)
+        setDetailInfo(null)
+        getData()
+      } catch (e:any) {
+        console.log(e)
+        alert('지원자 삭제 실패')
+      }
+    }
+    
+    const ApplicantInfo = ({applicant} : {applicant:any}) => {
+      return(
+        <tr className='text-center'>
+          <td className='border border-gray-500 py=[4px]'>{applicant.id}</td>
+          <td className='border border-gray-500 py=[4px]'>{applicant.participantName}</td>
+          <td className='border border-gray-500 py=[4px]'>{applicant.studentId}</td>
+          <td className='border border-gray-500 py=[4px] text-left'>
+            <div className='ml-[4px] p-2'>
+              <button className='bg-gray-700 text-white px-2 py-1 rounded' onClick={() => toggleDetail(applicant.id)} > {selectedId === applicant.id ? '닫기' : '보기' }</button>
+              {selectedId === applicant.id && (<div>
+                {detailInfo && <ApplicantDetailInfo applicant={detailInfo} /> }
+              </div> )}
+            </div>
+          </td>
+        </tr>
+      )
+    }
+
+    const DetailItem = ({label, value} : {label:string, value:string}) => {
+      return (
+        <div className='flex'>
+          <div className='w-[110px]'>{label}</div>
+          <div className='w-[576px]'>{value}</div>
+        </div>
+      )
+    }
+
+    const ApplicantDetailInfo = ({applicant} : {applicant:any}) => {
+      if(!applicant) return null
+      return (
+        <div className='flex flex-col space-y-[4px] p-4'>
+          <DetailItem label='연락처' value={applicant.contact} />
+          <DetailItem label='이메일' value={applicant.email}/>
+          <DetailItem label='학년' value={applicant.grade} />
+          <DetailItem label='학과' value={applicant.department} />
+          <div className='flex gap-[10px]'>
+            <button className='bg-gray-700 text-white px-2 py-1 rounded w-20'>
+            수정
+            </button>
+            <button className='bg-gray-700 text-white px-2 py-1 rounded w-20' onClick={() => handleDelete(applicant.id)}>
+            삭제
+            </button>
+          </div>
+        </div>
+      )
+    }
+
+    return (
+        <div className="h-[100vh] w-[100vw] bg-mainBlack font-pretendardRegular text-white flex flex-col items-center overflow-y-auto">
+          <div className='mb-[4px] mt-[155px] flex justify-between w-[1220px]'>
+          <div><span className='font-pretendardBold text-mainColor'>{count}</span>명의 지원자가 있습니다.</div>
+          </div>
+          <table className='w-[1220px]'>
+            <thead>
+              <tr className='border border-gray-500 py-[4px] font-pretendardBold'>
+                <th className="w-[60px]">ID</th>
+                <th className="border border-gray-500 py-[4px] w-[150px]">이름</th>
+                <th className="border border-gray-500 py-[4px] w-[150px]">학번</th>
+                <th className='border border-gray-500 py-[4px]'>상세정보</th>
+              </tr>
+            </thead>
+            <tbody>
+                {applicants.map((applicant) => (
+                  <ApplicantInfo key={applicant.id} applicant={applicant} />
+                ))}
+            </tbody>
+          </table>
+        </div>
+      )
+}
+
+export default SomkatonApplicants


### PR DESCRIPTION
# [Feat] 솜커톤 인원 관리 페이지 구현

##Issue
- #157 

## 변경 내용
- 솜커톤 인원 관리 페이지 추가

## 구현 사항
- 기존 지원조회 페이지 기반으로 페이지 구현
- 신청자 전체조회, 상세조회 기능 추가
- '보기' 버튼 클릭시 수정, 삭제 나타나도록 추가
- 신청자 삭제시 신청인원 리스트 재 렌더링 하도록 설정

## 테스트
![image](https://github.com/user-attachments/assets/083828a7-5ae3-4084-a17d-f008d5ea4719)

![image](https://github.com/user-attachments/assets/84117a78-1e71-4960-be06-cff882c3ebe2)

![image](https://github.com/user-attachments/assets/ca25f1ce-dde5-4156-af97-35e88ed65c73)


## 참고사항
- 신청자 정보 수정 구현중입니다.......

