### PR TITLE
[feat] 로그인 시 어드민 페이지 이동 및 리프레시 토큰 자동 관리 구현

### DIFF
--- a/src/components/layout/ProtectRoute.tsx
+++ b/src/components/layout/ProtectRoute.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { isAccessTokenValid, isRefreshTokenValid, removeTokens } from '../../utils/tokenUtils'
 
 interface ProtecteRouteProps {
   children: React.ReactNode
@@ -7,15 +8,56 @@ interface ProtecteRouteProps {
 
 const ProtectedRoute: React.FC<ProtecteRouteProps> = ({ children }) => {
   const navigate = useNavigate()
+  const [isAuthorized, setIsAuthorized] = useState(false)
+  const [isChecking, setIsChecking] = useState(true)
 
   useEffect(() => {
-    const accessToken = localStorage.getItem('accessToken')
+    const checkAuth = async () => {
+      try {
+        // 액세스 토큰이 유효한지 확인
+        if (isAccessTokenValid()) {
+          setIsAuthorized(true)
+          setIsChecking(false)
+          return
+        }
 
-    if (!accessToken) {
-      alert('권한이 필요한 페이지입니다.')
-      navigate('/') // 메인 페이지로 리다이렉트
+        // 리프레시 토큰이 유효한지 확인
+        if (isRefreshTokenValid()) {
+          // 리프레시 토큰이 있지만 액세스 토큰이 만료된 경우
+          // apiClient의 인터셉터가 자동으로 토큰을 갱신
+          setIsAuthorized(true)
+          setIsChecking(false)
+          return
+        }
+
+        // 토큰이 유효하지 않은 경우
+        removeTokens()
+        alert('로그인이 필요합니다.')
+        navigate('/login')
+      } catch (error) {
+        console.error('인증 확인 중 오류:', error)
+        removeTokens()
+        alert('인증 확인 중 오류가 발생했습니다.')
+        navigate('/login')
+      } finally {
+        setIsChecking(false)
+      }
     }
+
+    checkAuth()
   }, [navigate])
+
+  if (isChecking) {
+    return (
+      <div className="min-h-screen bg-[#17171B] flex items-center justify-center">
+        <div className="text-white text-lg">권한 확인 중...</div>
+      </div>
+    )
+  }
+
+  if (!isAuthorized) {
+    return null
+  }
 
   return <>{children}</>
 }

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios'
+import { getAccessToken, getRefreshToken, setTokens, removeTokens } from './tokenUtils'
 
 const API_BASE_URL =
   (process.env.DASOM_BASE_URL as string) ||
@@ -10,10 +11,34 @@ const apiClient = axios.create({
   timeout: 15000,
 })
 
+// 리프레시 토큰으로 새로운 액세스 토큰을 요청하는 함수
+const refreshAccessToken = async (): Promise<string | null> => {
+  try {
+    const refreshToken = getRefreshToken()
+    if (!refreshToken) return null
+
+    const response = await axios.post(`${API_BASE_URL}/auth/refresh`, {
+      refreshToken
+    })
+
+    const newAccessToken = response.data.accessToken
+    const newRefreshToken = response.data.refreshToken
+
+    if (newAccessToken && newRefreshToken) {
+      setTokens(newAccessToken, newRefreshToken)
+      return newAccessToken
+    }
+    return null
+  } catch (error) {
+    console.error('토큰 갱신 실패:', error)
+    removeTokens()
+    return null
+  }
+}
+
 apiClient.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
-    const accessToken =
-      typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null
+    const accessToken = getAccessToken()
 
     // 헤더 객체가 존재하도록 보장
     config.headers = config.headers || {}
@@ -44,7 +69,32 @@ apiClient.interceptors.request.use(
 apiClient.interceptors.response.use(
   response => response,
   async error => {
-    // 401 등의 공통 에러 처리 필요 시 이곳에서 수행 가능
+    const originalRequest = error.config
+
+    // 401 에러이고 토큰 갱신을 시도하지 않은 경우
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true
+
+      try {
+        const newAccessToken = await refreshAccessToken()
+        if (newAccessToken) {
+          // 새로운 토큰으로 원래 요청 재시도
+          originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`
+          return apiClient(originalRequest)
+        }
+      } catch (refreshError) {
+        console.error('토큰 갱신 중 오류:', refreshError)
+      }
+    }
+
+    // 401 에러가 지속되면 로그인 페이지로 리다이렉트
+    if (error.response?.status === 401) {
+      removeTokens()
+      if (typeof window !== 'undefined') {
+        window.location.href = '/login'
+      }
+    }
+
     return Promise.reject(error)
   }
 )

--- a/src/utils/tokenUtils.ts
+++ b/src/utils/tokenUtils.ts
@@ -1,0 +1,46 @@
+// 토큰 저장
+export const setTokens = (accessToken: string, refreshToken: string) => {
+  localStorage.setItem('accessToken', accessToken)
+  localStorage.setItem('refreshToken', refreshToken)
+}
+
+// 액세스 토큰 가져오기
+export const getAccessToken = (): string | null => {
+  return localStorage.getItem('accessToken')
+}
+
+// 리프레시 토큰 가져오기
+export const getRefreshToken = (): string | null => {
+  return localStorage.getItem('refreshToken')
+}
+
+// 토큰 제거
+export const removeTokens = () => {
+  localStorage.removeItem('accessToken')
+  localStorage.removeItem('refreshToken')
+}
+
+// 토큰 유효성 검사 (간단한 JWT 만료 시간 체크)
+export const isTokenExpired = (token: string): boolean => {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]))
+    const currentTime = Date.now() / 1000
+    return payload.exp < currentTime
+  } catch {
+    return true
+  }
+}
+
+// 액세스 토큰이 유효한지 확인
+export const isAccessTokenValid = (): boolean => {
+  const token = getAccessToken()
+  if (!token) return false
+  return !isTokenExpired(token)
+}
+
+// 리프레시 토큰이 유효한지 확인
+export const isRefreshTokenValid = (): boolean => {
+  const token = getRefreshToken()
+  if (!token) return false
+  return !isTokenExpired(token)
+}


### PR DESCRIPTION
# [feat] 로그인 시 어드민 페이지 이동 및 리프레시 토큰 자동 관리 구현

## Issue
- #227 

## 변경 내용
- 로그인 성공 시 자동으로 어드민 페이지(/admin)로 이동하도록 수정
- 리프레시 토큰을 활용한 자동 토큰 갱신 시스템 구현
- 토큰 관리 유틸리티 함수들을 별도 파일로 분리
- API 요청 시 401 에러 발생 시 자동으로 토큰 갱신 및 재시도 로직 추가

## 체크리스트
PR을 제출하기 전에 다음 사항들을 확인해주세요:

- [x] 커밋 메시지가 컨벤션을 따르는가?
- [x] 린트 검사를 통과했는가? (`npm run lint` or `npm run lint:fix`)
- [x] 로컬에서 빌드가 성공하는가? (`npm run build`)

## 테스트

- [x] 로컬에서 테스트 완료
- [x] 기존 기능에 영향 없음 확인
- [ ] 다양한 브라우저에서 테스트 (필요시)